### PR TITLE
Feature/objects 724 get by object urn starts with

### DIFF
--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -155,7 +155,7 @@ public class ObjectPersistenceService implements IObjectDao {
         if (MapUtils.getLong(queryParameters, QueryParameterType.MODIFIED_AFTER) != null){
             modifiedAfterDate = (Long) queryParameters.get(QueryParameterType.MODIFIED_AFTER);
         }
-        ObjectEntity exampleEntity = builder.build();
+        ObjectEntity exampleEntity = builder.accountId(UuidUtil.getUuidFromAccountUrn(accountUrn)).build();
 
         Example<ObjectEntity> example = Example.of(exampleEntity, matcher);
 

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -79,10 +79,17 @@ public class ObjectPersistenceService implements IObjectDao {
         }
     }
 
+    /**
+     * Finds objects matching a specified object URN start.
+     *
+     * @param accountUrn the account URN
+     * @param objectUrnStartsWith the first characters of the object URN
+     * @return all objects whose {@code objectUrn} starts with {@code objectUrnStartsWith}
+     */
     @Override
-    public List<ObjectResponse> findByObjectUrnStartsWith(String accountUrn, String objectUrn) {
+    public List<ObjectResponse> findByObjectUrnStartsWith(String accountUrn, String objectUrnStartsWith) {
 
-        List<ObjectEntity> entityList = objectRepository.findByAccountIdAndObjectUrnStartsWith(UuidUtil.getUuidFromAccountUrn(accountUrn), objectUrn);
+        List<ObjectEntity> entityList = objectRepository.findByAccountIdAndObjectUrnStartsWith(UuidUtil.getUuidFromAccountUrn(accountUrn), objectUrnStartsWith);
 
         return entityList.stream()
             .map(o -> conversionService.convert(o, ObjectResponse.class))

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -4,10 +4,10 @@ import net.smartcosmos.dao.objects.IObjectDao;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
 import net.smartcosmos.dao.objects.repository.IObjectRepository;
 import net.smartcosmos.dto.objects.ObjectCreate;
-import net.smartcosmos.dto.objects.ObjectUpdate;
 import net.smartcosmos.dto.objects.ObjectResponse;
-import org.apache.commons.collections4.MapUtils;
+import net.smartcosmos.dto.objects.ObjectUpdate;
 import net.smartcosmos.util.UuidUtil;
+import org.apache.commons.collections4.MapUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.Example;
@@ -20,10 +20,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.springframework.data.domain.ExampleMatcher.GenericPropertyMatchers.startsWith;
-import static org.springframework.data.domain.ExampleMatcher.GenericPropertyMatchers.endsWith;
-import static org.springframework.data.domain.ExampleMatcher.GenericPropertyMatchers.exact;
-import static org.springframework.data.domain.ExampleMatcher.GenericPropertyMatchers.regex;
 import static org.springframework.data.domain.ExampleMatcher.StringMatcher.STARTING;
 
 /**
@@ -81,6 +77,16 @@ public class ObjectPersistenceService implements IObjectDao {
         else {
             return Optional.empty();
         }
+    }
+
+    @Override
+    public List<ObjectResponse> findByObjectUrnStartsWith(String accountUrn, String objectUrn) {
+
+        List<ObjectEntity> entityList = objectRepository.findByAccountIdAndObjectUrnStartsWith(UuidUtil.getUuidFromAccountUrn(accountUrn), objectUrn);
+
+        return entityList.stream()
+            .map(o -> conversionService.convert(o, ObjectResponse.class))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/net/smartcosmos/dao/objects/repository/IObjectRepository.java
+++ b/src/main/java/net/smartcosmos/dao/objects/repository/IObjectRepository.java
@@ -4,6 +4,7 @@ import net.smartcosmos.dao.objects.domain.ObjectEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,4 +17,6 @@ public interface IObjectRepository extends JpaRepository<ObjectEntity, UUID>, Qu
     Optional<ObjectEntity> findByAccountIdAndObjectUrn(UUID accountId, String objectUrn);
 
     Optional<ObjectEntity> findByAccountIdAndId(UUID accountId, UUID id);
+
+    List<ObjectEntity> findByAccountIdAndObjectUrnStartsWith(UUID accountId, String objectUrn);
 }

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -148,7 +148,7 @@ public class ObjectPersistenceServiceTest {
     public void findByObjectUrnStartsWith() throws Exception {
         populateQueryData();
 
-        List<ObjectResponse> response = objectPersistenceService.findByObjectUrnStartsWith(accountUrn, "objectUrn");
+        List<ObjectResponse> response = objectPersistenceService.findByObjectUrnStartsWith(accountUrn, OBJECT_URN_QUERY_PARAMS);
 
         assertEquals(12, response.size());
     }
@@ -362,6 +362,29 @@ public class ObjectPersistenceServiceTest {
         queryParams.put(MODIFIED_AFTER, fourthDate);
         response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
         actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+    }
+
+    /**
+     * Test case for OBJECTS-725 findByQueryParams ignores account
+     * @throws Exception
+     */
+    @Test
+    public void findByQueryParametersDifferentAccountUrns() throws Exception {
+        populateQueryData();
+
+        Map<QueryParameterType, Object> queryParams = new HashMap<>();
+        queryParams.put(QueryParameterType.OBJECT_URN_LIKE, OBJECT_URN_QUERY_PARAMS);
+
+        final UUID newAccountUuid = UuidUtil.getNewUuid();
+        final String newAccountUrn = UuidUtil.getAccountUrnFromUuid(newAccountUuid);
+
+        int expectedSize = 0;
+        int actualSize = 0;
+
+        List<ObjectResponse> response = objectPersistenceService.findByQueryParameters(newAccountUrn, queryParams);
+        actualSize = response.size();
+
         assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
     }
 

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -11,7 +11,6 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 import net.smartcosmos.util.UuidUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -370,7 +369,6 @@ public class ObjectPersistenceServiceTest {
      * Test case for OBJECTS-725 findByQueryParams ignores account
      * @throws Exception
      */
-    @Ignore
     @Test
     public void findByQueryParametersDifferentAccountUrns() throws Exception {
         populateQueryData();

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -1,16 +1,19 @@
 package net.smartcosmos.dao.objects.impl;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.junit.*;
-import org.junit.runner.*;
-import org.mockito.*;
+import net.smartcosmos.dao.objects.IObjectDao.QueryParameterType;
+import net.smartcosmos.dao.objects.ObjectPersistenceConfig;
+import net.smartcosmos.dao.objects.ObjectPersistenceTestApplication;
+import net.smartcosmos.dao.objects.domain.ObjectEntity;
+import net.smartcosmos.dao.objects.repository.IObjectRepository;
+import net.smartcosmos.dto.objects.ObjectCreate;
+import net.smartcosmos.dto.objects.ObjectResponse;
+import net.smartcosmos.security.user.SmartCosmosUser;
+import net.smartcosmos.util.UuidUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -22,20 +25,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import net.smartcosmos.dao.objects.IObjectDao.QueryParameterType;
-import net.smartcosmos.dao.objects.ObjectPersistenceConfig;
-import net.smartcosmos.dao.objects.ObjectPersistenceTestApplication;
-import net.smartcosmos.dao.objects.domain.ObjectEntity;
-import net.smartcosmos.dao.objects.repository.IObjectRepository;
-import net.smartcosmos.dto.objects.ObjectCreate;
-import net.smartcosmos.dto.objects.ObjectResponse;
-import net.smartcosmos.security.user.SmartCosmosUser;
-import net.smartcosmos.util.UuidUtil;
+import java.util.*;
 
 import static net.smartcosmos.dao.objects.IObjectDao.QueryParameterType.MODIFIED_AFTER;
 import static net.smartcosmos.dao.objects.IObjectDao.QueryParameterType.MONIKER_LIKE;
-import static net.smartcosmos.dao.objects.IObjectDao.QueryParameterType.TYPE;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author voor
@@ -121,6 +116,8 @@ public class ObjectPersistenceServiceTest {
         assertEquals("urn:fakeUrn", response.getObjectUrn());
     }
 
+    // region Find By Object URN
+
     @Test
     public void findByObjectUrn() throws Exception {
 
@@ -137,6 +134,28 @@ public class ObjectPersistenceServiceTest {
 
         assertTrue(response.isPresent());
     }
+
+    @Test
+    public void findByObjectUrnStartsWithNonexistent() throws Exception {
+        populateQueryData();
+
+        List<ObjectResponse> response = objectPersistenceService.findByObjectUrnStartsWith(accountUrn, "no-such-urn");
+
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    public void findByObjectUrnStartsWith() throws Exception {
+        populateQueryData();
+
+        List<ObjectResponse> response = objectPersistenceService.findByObjectUrnStartsWith(accountUrn, "objectUrn");
+
+        assertEquals(12, response.size());
+    }
+
+    // endregion
+
+    // region Find by Query Parameters
 
     // no query data should return an empty response
     @Test
@@ -346,45 +365,47 @@ public class ObjectPersistenceServiceTest {
         assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
     }
 
+    // endregion
+
+    // region Helper Methods
+
     // used by findByQueryParametersStringParameters()
     private void populateQueryData() throws Exception {
 
-        final UUID accountUuid = UuidUtil.getNewUuid();
-
-        ObjectEntity entityNameOneTypeOne = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityNameOneTypeOne = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_01).name(NAME_ONE).type(TYPE_ONE).build();
 
-        ObjectEntity entityNameTwoTypeOne = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityNameTwoTypeOne = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_02).name(NAME_TWO).type(TYPE_ONE).build();
 
-        ObjectEntity entityNameThreeTypeOne = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityNameThreeTypeOne = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_03).name(NAME_THREE).type(TYPE_ONE).build();
 
-        ObjectEntity entityNameOneTypeTwo = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityNameOneTypeTwo = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_04).name(NAME_ONE).type(TYPE_TWO).build();
 
-        ObjectEntity entityNameTwoTypeTwo = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityNameTwoTypeTwo = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_05).name(NAME_TWO).type(TYPE_TWO).build();
 
-        ObjectEntity entityNameThreeTypeTwo = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityNameThreeTypeTwo = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_06).name(NAME_THREE).type(TYPE_TWO).build();
 
-        ObjectEntity entityNameOneMonikerOne = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityNameOneMonikerOne = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_07).name(NAME_ONE).type(WHATEVER).moniker(MONIKER_ONE).build();
 
-        ObjectEntity entityNameOneMonikerTwo = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityNameOneMonikerTwo = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_08).name(NAME_ONE).type(WHATEVER).moniker(MONIKER_TWO).build();
 
-        ObjectEntity entityNameOneMonikerThree = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityNameOneMonikerThree = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_09).name(NAME_ONE).type(WHATEVER).moniker(MONIKER_THREE).build();
 
-        ObjectEntity entityObjectUrn10 = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityObjectUrn10 = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_10).name(WHATEVER).type(WHATEVER).build();
 
-        ObjectEntity entityObjectUrn11 = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityObjectUrn11 = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_11).name(WHATEVER).type(WHATEVER).build();
 
-        ObjectEntity entityObjectUrn12 = ObjectEntity.builder().accountId(accountUuid)
+        ObjectEntity entityObjectUrn12 = ObjectEntity.builder().accountId(accountId)
             .objectUrn(OBJECT_URN_QUERY_PARAMS_12).name(WHATEVER).type(WHATEVER).build();
 
         objectRepository.save(entityNameOneTypeOne);
@@ -400,5 +421,7 @@ public class ObjectPersistenceServiceTest {
         objectRepository.save(entityObjectUrn11);
         objectRepository.save(entityObjectUrn12);
     }
+
+    // endregion
 
 }

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -11,6 +11,7 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 import net.smartcosmos.util.UuidUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -369,6 +370,7 @@ public class ObjectPersistenceServiceTest {
      * Test case for OBJECTS-725 findByQueryParams ignores account
      * @throws Exception
      */
+    @Ignore
     @Test
     public void findByQueryParametersDifferentAccountUrns() throws Exception {
         populateQueryData();


### PR DESCRIPTION
### What changes were proposed in this pull request?

First of all, the `findByObjectUrnStartsWith()` method is implemented.

In addition, a bug in the `populateQueryData()` helper method is fixed: It previously created objects in a new realm which is never used in lookups, because a new `accountUrn` was created. Now, it uses the class-level URN, too.

It also includes the fix for _[OBJECTS-725 findByQueryParams ignores account](https://smartractechnology.atlassian.net/browse/OBJECTS-725)_
### How is this patch documented?

Javadoc.
### How was this patch tested?

Unit tests.
#### Depends On
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-objects/pull/12
