### PR TITLE
Search by query params using specifications

### DIFF
--- a/src/main/java/net/smartcosmos/dao/objects/converter/ObjectEntityToObjectResponseConverter.java
+++ b/src/main/java/net/smartcosmos/dao/objects/converter/ObjectEntityToObjectResponseConverter.java
@@ -8,6 +8,9 @@ import org.springframework.format.FormatterRegistrar;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author voor
  */
@@ -35,6 +38,14 @@ public class ObjectEntityToObjectResponseConverter
                 .description(entity.getDescription())
                 // Don't forget to build it!
                 .build();
+    }
+
+    public List convertAll(Iterable<ObjectEntity> entities) {
+        List<ObjectResponse> convertedList = new ArrayList<>();
+        for (ObjectEntity entity: entities) {
+            convertedList.add(convert(entity));
+        }
+        return convertedList;
     }
 
     @Override

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -1,6 +1,6 @@
 package net.smartcosmos.dao.objects.impl;
 
-import net.smartcosmos.dao.objects.IObjectDao;
+import net.smartcosmos.dao.objects.ObjectDao;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
 import net.smartcosmos.dao.objects.repository.IObjectRepository;
 import net.smartcosmos.dao.objects.util.ObjectsPersistenceUtil;
@@ -35,7 +35,7 @@ import static org.springframework.data.jpa.domain.Specifications.where;
  * @author voor
  */
 @Service
-public class ObjectPersistenceService implements IObjectDao {
+public class ObjectPersistenceService implements ObjectDao {
 
     private final IObjectRepository objectRepository;
     private final ConversionService conversionService;

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -7,13 +7,12 @@ import net.smartcosmos.dao.objects.util.ObjectsPersistenceUtil;
 import net.smartcosmos.dto.objects.ObjectCreate;
 import net.smartcosmos.dto.objects.ObjectResponse;
 import net.smartcosmos.dto.objects.ObjectUpdate;
-import org.apache.commons.collections4.MapUtils;
 import net.smartcosmos.util.UuidUtil;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
-import org.springframework.data.domain.Example;
-import org.springframework.data.domain.ExampleMatcher;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionException;
 import org.springframework.util.StringUtils;
@@ -29,7 +28,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.springframework.data.domain.ExampleMatcher.StringMatcher.STARTING;
+import static org.springframework.data.jpa.domain.Specifications.where;
 
 /**
  * @author voor
@@ -43,7 +42,7 @@ public class ObjectPersistenceService implements IObjectDao {
 
     @Autowired
     public ObjectPersistenceService(IObjectRepository objectRepository,
-            ConversionService conversionService, Validator basicValidator) {
+                                    ConversionService conversionService, Validator basicValidator) {
         this.objectRepository = objectRepository;
         this.conversionService = conversionService;
         this.validator = basicValidator;
@@ -85,7 +84,7 @@ public class ObjectPersistenceService implements IObjectDao {
 
         if (entity.isPresent()) {
             final ObjectResponse response = conversionService.convert(entity.get(),
-                    ObjectResponse.class);
+                ObjectResponse.class);
             return Optional.ofNullable(response);
         }
         else {
@@ -103,7 +102,8 @@ public class ObjectPersistenceService implements IObjectDao {
     @Override
     public List<ObjectResponse> findByObjectUrnStartsWith(String accountUrn, String objectUrnStartsWith) {
 
-        List<ObjectEntity> entityList = objectRepository.findByAccountIdAndObjectUrnStartsWith(UuidUtil.getUuidFromAccountUrn(accountUrn), objectUrnStartsWith);
+        List<ObjectEntity> entityList = objectRepository.findByAccountIdAndObjectUrnStartsWith(UuidUtil.getUuidFromAccountUrn(accountUrn),
+            objectUrnStartsWith);
 
         return entityList.stream()
             .map(o -> conversionService.convert(o, ObjectResponse.class))
@@ -113,7 +113,8 @@ public class ObjectPersistenceService implements IObjectDao {
     @Override
     public Optional<ObjectResponse> findByUrn(String accountUrn, String urn) {
 
-        Optional<ObjectEntity> entity = objectRepository.findByAccountIdAndId(UuidUtil.getUuidFromAccountUrn(accountUrn), UuidUtil.getUuidFromUrn(urn));
+        Optional<ObjectEntity> entity = objectRepository.findByAccountIdAndId(UuidUtil.getUuidFromAccountUrn(accountUrn),
+            UuidUtil.getUuidFromUrn(urn));
 
         if (entity.isPresent()) {
             final ObjectResponse response = conversionService.convert(entity.get(),
@@ -137,8 +138,8 @@ public class ObjectPersistenceService implements IObjectDao {
         // it'll happen fairly often and in numerous places, but for example sake it's
         // done inline here.
         return objectRepository.findAll().stream()
-                .map(o -> conversionService.convert(o, ObjectResponse.class))
-                .collect(Collectors.toList());
+            .map(o -> conversionService.convert(o, ObjectResponse.class))
+            .collect(Collectors.toList());
     }
 
     /**
@@ -153,39 +154,58 @@ public class ObjectPersistenceService implements IObjectDao {
      */
     public List<ObjectResponse> findByQueryParameters(String accountUrn, Map<QueryParameterType, Object> queryParameters) {
 
-        ObjectEntity.ObjectEntityBuilder builder = ObjectEntity.builder();
-        ExampleMatcher matcher = ExampleMatcher.matching()
-            .withStringMatcher(STARTING);
-            //.withMatcher(QueryParameterType.TYPE.typeName(), exact()) // would be nice, but broken in Spring
+        SearchSpecifications searchSpecifications = new SearchSpecifications<ObjectEntity>();
 
-        builder.objectUrn(MapUtils.getString(queryParameters, QueryParameterType.OBJECT_URN_LIKE));
-        builder.type(MapUtils.getString(queryParameters, QueryParameterType.TYPE));
-        builder.name(MapUtils.getString(queryParameters, QueryParameterType.NAME_LIKE));
-        builder.moniker(MapUtils.getString(queryParameters, QueryParameterType.MONIKER_LIKE));
+        Specification accountUrnSpecification = null;
+        if (accountUrn != null) {
+            UUID accountUuid = UuidUtil.getUuidFromAccountUrn(accountUrn);
+            accountUrnSpecification = searchSpecifications.matchUuid(accountUuid, "accountId");
+        };
 
-        // findByExample doesn't deal with dates, so we have to do it ourselves
-        Long modifiedAfterDate = null;
+        Specification objectUrnSpecification = null;
+        String objectUrnLike = MapUtils.getString(queryParameters, QueryParameterType.OBJECT_URN_LIKE);
+        if (objectUrnLike != null) {
+            objectUrnSpecification = searchSpecifications.stringStartsWith(objectUrnLike, QueryParameterType.OBJECT_URN_FIELD_NAME.typeName());
+        };
 
-        if (MapUtils.getLong(queryParameters, QueryParameterType.MODIFIED_AFTER) != null){
-            modifiedAfterDate = (Long) queryParameters.get(QueryParameterType.MODIFIED_AFTER);
+        Specification nameLikeSpecification = null;
+        String nameLike = MapUtils.getString(queryParameters, QueryParameterType.NAME_LIKE);
+        if (nameLike != null) {
+            nameLikeSpecification = searchSpecifications.stringStartsWith(nameLike, QueryParameterType.NAME_FIELD_NAME.typeName());
+        };
+
+        Specification typeSpecification = null;
+        String type = MapUtils.getString(queryParameters, QueryParameterType.TYPE);
+        if (type != null) {
+            typeSpecification = searchSpecifications.stringMatchesExactly(type, QueryParameterType.TYPE_FIELD_NAME.typeName());
+        };
+
+        Specification monikerLikeSpecification = null;
+        String monikerLike = MapUtils.getString(queryParameters, QueryParameterType.MONIKER_LIKE);
+        if (monikerLike != null) {
+            monikerLikeSpecification = searchSpecifications.stringStartsWith(monikerLike, QueryParameterType.MONIKER_FIELD_NAME.typeName());
+        };
+
+        Specification lastModifedAfterSpecification = null;
+        Long lastModifedAfter = MapUtils.getLong(queryParameters, QueryParameterType.MODIFIED_AFTER);
+        if (lastModifedAfter != null) {
+            lastModifedAfterSpecification = searchSpecifications.numberGreaterThan(lastModifedAfter,
+                QueryParameterType.MODIFIED_AFTER_FIELD_NAME.typeName());
+        };
+
+        Iterable<ObjectEntity> returnedValues = objectRepository.findAll(where(objectUrnSpecification)
+            .and(accountUrnSpecification)
+            .and(nameLikeSpecification)
+            .and(typeSpecification)
+            .and(monikerLikeSpecification)
+            .and(lastModifedAfterSpecification));
+
+        List<ObjectResponse> convertedList = new ArrayList<>();
+        for (ObjectEntity entity: returnedValues) {
+            convertedList.add(conversionService.convert(entity, ObjectResponse.class));
         }
-        ObjectEntity exampleEntity = builder.accountId(UuidUtil.getUuidFromAccountUrn(accountUrn)).build();
+        return convertedList;
 
-        Example<ObjectEntity> example = Example.of(exampleEntity, matcher);
-
-        Iterable<ObjectEntity> queryResult =  objectRepository.findAll(example);
-        List<ObjectResponse> returnValue = new ArrayList<>();
-
-        for (ObjectEntity singleResult : queryResult)
-        {
-            // created is set at object creation time, and lastModified is not
-            Long singleResultLastModified = singleResult.getLastModified();
-            if(modifiedAfterDate == null || singleResultLastModified > modifiedAfterDate)
-            {
-                returnValue.add(conversionService.convert(singleResult, ObjectResponse.class));
-            }
-        }
-        return returnValue;
     }
 
     private Optional<ObjectEntity> findEntity(UUID accountId, String urn, String objectUrn) throws IllegalArgumentException {

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -4,6 +4,7 @@ import net.smartcosmos.dao.objects.IObjectDao;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
 import net.smartcosmos.dao.objects.repository.IObjectRepository;
 import net.smartcosmos.dao.objects.util.ObjectsPersistenceUtil;
+import net.smartcosmos.dao.objects.util.SearchSpecifications;
 import net.smartcosmos.dto.objects.ObjectCreate;
 import net.smartcosmos.dto.objects.ObjectResponse;
 import net.smartcosmos.dto.objects.ObjectUpdate;

--- a/src/main/java/net/smartcosmos/dao/objects/impl/SearchSpecifications.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/SearchSpecifications.java
@@ -1,0 +1,83 @@
+package net.smartcosmos.dao.objects.impl;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.UUID;
+
+/**
+ * Initially created by SMART COSMOS Team on May 26, 2016.
+ *
+ * T is the Entity type (e.g., net.smartcosmos.dao.objects.domain.ObjectEntity)
+ */
+public class SearchSpecifications<T>
+{
+    //
+    // The public methods, which return specifications
+    //
+    public Specification<T> matchUuid(UUID uuid, String fieldName) {
+        return (root, criteriaQuery, criteriaBuilder) ->
+            uuidMatches(root, criteriaQuery, criteriaBuilder, uuid, fieldName);
+    }
+
+    public Specification<T> stringStartsWith(String startsWith, String queryParameter) {
+        return (root, criteriaQuery, criteriaBuilder) ->
+            stringStartsWith(root, criteriaQuery, criteriaBuilder, startsWith, queryParameter);
+    }
+
+    public Specification<T> stringEndsWith(String endsWith, String queryParameter) {
+        return (root, criteriaQuery, criteriaBuilder) ->
+            stringEndsWith(root, criteriaQuery, criteriaBuilder, endsWith, queryParameter);
+    }
+
+    public Specification<T> stringMatchesExactly(String matchesExactly, String queryParameter) {
+        return (root, criteriaQuery, criteriaBuilder) ->
+            stringMatchesExactly(root, criteriaQuery, criteriaBuilder, matchesExactly, queryParameter);
+    }
+
+    public Specification<T> numberLessThan(Number lessThan, String queryParameter) {
+        return (root, criteriaQuery, criteriaBuilder) ->
+            numberLessThan(root, criteriaQuery, criteriaBuilder, lessThan, queryParameter);
+    }
+
+    public Specification<T> numberGreaterThan(Number greaterThan, String queryParameter) {
+        return (root, criteriaQuery, criteriaBuilder) ->
+            numberGreaterThan(root, criteriaQuery, criteriaBuilder, greaterThan, queryParameter);
+    }
+
+    //
+    // The private methods, which return Predicates
+    //
+    private Predicate uuidMatches(Root root, CriteriaQuery<?> query,
+                                  CriteriaBuilder builder, UUID matches, String queryParameter) {
+        return builder.equal(root.get(queryParameter), matches);
+    }
+
+    private Predicate stringStartsWith(Root root, CriteriaQuery<?> query,
+                                       CriteriaBuilder builder, String startsWith, String queryParameter) {
+        return builder.like(root.get(queryParameter), startsWith + "%");
+    }
+
+    private Predicate stringEndsWith(Root root, CriteriaQuery<?> query,
+                                     CriteriaBuilder builder, String endsWith, String queryParameter) {
+        return builder.like(root.get(queryParameter), "%" + endsWith);
+    }
+
+    private Predicate stringMatchesExactly(Root root, CriteriaQuery<?> query,
+                                           CriteriaBuilder builder, String matchesExactly, String queryParameter) {
+        return builder.equal(root.get(queryParameter), matchesExactly);
+    }
+
+    private Predicate numberLessThan(Root root, CriteriaQuery<?> query,
+                                     CriteriaBuilder builder, Number numberLessThan, String queryParameter) {
+        return builder.lt(root.get(queryParameter), numberLessThan);
+    }
+
+    private Predicate numberGreaterThan(Root root, CriteriaQuery<?> query,
+                                        CriteriaBuilder builder, Number numberGreaterThan, String queryParameter) {
+        return builder.gt(root.get(queryParameter), numberGreaterThan);
+    }
+}

--- a/src/main/java/net/smartcosmos/dao/objects/repository/IObjectRepository.java
+++ b/src/main/java/net/smartcosmos/dao/objects/repository/IObjectRepository.java
@@ -2,6 +2,8 @@ package net.smartcosmos.dao.objects.repository;
 
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
 
 import java.util.List;
@@ -11,7 +13,8 @@ import java.util.UUID;
 /**
  * @author voor
  */
-public interface IObjectRepository extends JpaRepository<ObjectEntity, UUID>, QueryByExampleExecutor<ObjectEntity>
+public interface IObjectRepository
+    extends JpaRepository<ObjectEntity, UUID>, QueryByExampleExecutor<ObjectEntity>, JpaSpecificationExecutor<ObjectEntity>
 {
 
     Optional<ObjectEntity> findByAccountIdAndObjectUrn(UUID accountId, String objectUrn);
@@ -19,4 +22,5 @@ public interface IObjectRepository extends JpaRepository<ObjectEntity, UUID>, Qu
     Optional<ObjectEntity> findByAccountIdAndId(UUID accountId, UUID id);
 
     List<ObjectEntity> findByAccountIdAndObjectUrnStartsWith(UUID accountId, String objectUrn);
+
 }

--- a/src/main/java/net/smartcosmos/dao/objects/util/SearchSpecifications.java
+++ b/src/main/java/net/smartcosmos/dao/objects/util/SearchSpecifications.java
@@ -1,4 +1,4 @@
-package net.smartcosmos.dao.objects.impl;
+package net.smartcosmos.dao.objects.util;
 
 import org.springframework.data.jpa.domain.Specification;
 

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -1,6 +1,6 @@
 package net.smartcosmos.dao.objects.impl;
 
-import net.smartcosmos.dao.objects.IObjectDao.QueryParameterType;
+import net.smartcosmos.dao.objects.ObjectDao.QueryParameterType;
 import net.smartcosmos.dao.objects.ObjectPersistenceConfig;
 import net.smartcosmos.dao.objects.ObjectPersistenceTestApplication;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
@@ -35,8 +35,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static net.smartcosmos.dao.objects.IObjectDao.QueryParameterType.MODIFIED_AFTER;
-import static net.smartcosmos.dao.objects.IObjectDao.QueryParameterType.MONIKER_LIKE;
+import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.MODIFIED_AFTER;
+import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.MONIKER_LIKE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -504,8 +504,8 @@ public class ObjectPersistenceServiceTest {
         assertFalse(responseUpdate.isPresent());
     }
 
-    @Test(expected=ConstraintViolationException.class)
-    public void thatUpdateWithoutIdThrowsException() {
+    @Test
+    public void thatUpdateWithoutIdReturnsNothing() {
 
         String objectUrn = "urn:fakeUrn-update3";
         String name = "name";
@@ -538,10 +538,11 @@ public class ObjectPersistenceServiceTest {
             .name(newName)
             .build();
         Optional<ObjectResponse> responseUpdate = objectPersistenceService.update(accountUrn, update);
+        assertFalse(responseUpdate.isPresent());
     }
 
-    @Test(expected=ConstraintViolationException.class)
-    public void thatUpdateByOverspecifiedIdThrowsException() {
+    @Test
+    public void thatUpdateByOverspecifiedIdIsOkIfUrnAndObjectUrnMatch() {
 
         String objectUrn = "urn:fakeUrn-update4";
         String name = "name";
@@ -578,7 +579,7 @@ public class ObjectPersistenceServiceTest {
         Optional<ObjectResponse> responseUpdate = objectPersistenceService.update(accountUrn, update);
     }
 
-    @Test(expected=ConstraintViolationException.class)
+    @Test(expected=IllegalArgumentException.class)
     public void thatUpdateByOverspecifiedAndConflictingIdThrowsException() {
 
         String objectUrn = "urn:fakeUrn-update5";

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -744,13 +744,8 @@ public class ObjectPersistenceServiceTest {
         List<ObjectResponse> response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
         assertTrue(response.size() == 3);
 
-        // The next two tests should verify that type does exact matching, unlike objectUrn, name, and moniker, and
-        // in a perfect world the first of the two tests would also return 0.
-        // Unfortunately, the exact() matcher is broken in Spring. If they ever fix it, uncomment the line containing
-        // "exact()" in ObjectPersistenceService.java
-        // Only one field-specific matcher per field, unfortunately, so a combination of startsWith() and EndsWith()
-        // doesn't work either.
-        expectedSize = 3;
+        // verify that matching of the type field is exact
+        expectedSize = 0;
         queryParams.put(QueryParameterType.TYPE, "type o");
         response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
         actualSize = response.size();


### PR DESCRIPTION
### What changes were proposed in this pull request?

findByQueryParameters now handled by Spring Specification. There's a file called SearchSpecifications in util, and ObjectsPersistenceService:findByQueryParameters has been completely redone.
The tests that were already in place in ObjectsPersistenceServiceTest are all passing.
### How is this patch documented?

Javadoc, both ours and Spring's. I'll add some commentary tomorrow (27.5) morning.
### How was this patch tested?

Already existing unit tests in ObjectsPersistenceServiceTest. All passing.
#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-objects/pull/13
for additional fields in IObjectDao.QueryParameters.
