### PR TITLE
Feature/remove dto constraints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,6 @@
             <version>4.1</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/src/main/java/net/smartcosmos/dao/objects/ObjectPersistenceConfig.java
+++ b/src/main/java/net/smartcosmos/dao/objects/ObjectPersistenceConfig.java
@@ -2,17 +2,14 @@ package net.smartcosmos.dao.objects;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.orm.jpa.EntityScan;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.format.FormatterRegistrar;
 import org.springframework.format.FormatterRegistry;
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
-import javax.validation.Validator;
 import java.util.Map;
 
 /**
@@ -33,10 +30,5 @@ public class ObjectPersistenceConfig extends WebMvcConfigurerAdapter {
         for (FormatterRegistrar registrar : formatterRegistrarMap.values()) {
             registrar.registerFormatters(registry);
         }
-    }
-
-    @Bean
-    public Validator basicValidator() {
-        return new LocalValidatorFactoryBean();
     }
 }

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -150,44 +150,44 @@ public class ObjectPersistenceService implements ObjectDao {
      */
     public List<ObjectResponse> findByQueryParameters(String accountUrn, Map<QueryParameterType, Object> queryParameters) {
 
-        SearchSpecifications searchSpecifications = new SearchSpecifications<ObjectEntity>();
+        SearchSpecifications<ObjectEntity> searchSpecifications = new SearchSpecifications<ObjectEntity>();
 
-        Specification accountUrnSpecification = null;
+        Specification<ObjectEntity> accountUrnSpecification = null;
         if (accountUrn != null) {
             UUID accountUuid = UuidUtil.getUuidFromAccountUrn(accountUrn);
             accountUrnSpecification = searchSpecifications.matchUuid(accountUuid, "accountId");
-        };
+        }
 
-        Specification objectUrnSpecification = null;
+        Specification<ObjectEntity> objectUrnSpecification = null;
         String objectUrnLike = MapUtils.getString(queryParameters, QueryParameterType.OBJECT_URN_LIKE);
         if (objectUrnLike != null) {
             objectUrnSpecification = searchSpecifications.stringStartsWith(objectUrnLike, QueryParameterType.OBJECT_URN_FIELD_NAME.typeName());
-        };
+        }
 
-        Specification nameLikeSpecification = null;
+        Specification<ObjectEntity> nameLikeSpecification = null;
         String nameLike = MapUtils.getString(queryParameters, QueryParameterType.NAME_LIKE);
         if (nameLike != null) {
             nameLikeSpecification = searchSpecifications.stringStartsWith(nameLike, QueryParameterType.NAME_FIELD_NAME.typeName());
-        };
+        }
 
-        Specification typeSpecification = null;
+        Specification<ObjectEntity> typeSpecification = null;
         String type = MapUtils.getString(queryParameters, QueryParameterType.TYPE);
         if (type != null) {
             typeSpecification = searchSpecifications.stringMatchesExactly(type, QueryParameterType.TYPE_FIELD_NAME.typeName());
-        };
+        }
 
-        Specification monikerLikeSpecification = null;
+        Specification<ObjectEntity> monikerLikeSpecification = null;
         String monikerLike = MapUtils.getString(queryParameters, QueryParameterType.MONIKER_LIKE);
         if (monikerLike != null) {
             monikerLikeSpecification = searchSpecifications.stringStartsWith(monikerLike, QueryParameterType.MONIKER_FIELD_NAME.typeName());
-        };
+        }
 
-        Specification lastModifedAfterSpecification = null;
+        Specification<ObjectEntity> lastModifedAfterSpecification = null;
         Long lastModifedAfter = MapUtils.getLong(queryParameters, QueryParameterType.MODIFIED_AFTER);
         if (lastModifedAfter != null) {
             lastModifedAfterSpecification = searchSpecifications.numberGreaterThan(lastModifedAfter,
                 QueryParameterType.MODIFIED_AFTER_FIELD_NAME.typeName());
-        };
+        }
 
         Iterable<ObjectEntity> returnedValues = objectRepository.findAll(where(objectUrnSpecification)
             .and(accountUrnSpecification)

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -62,6 +62,7 @@ public class ObjectPersistenceService implements IObjectDao {
     public Optional<ObjectResponse> update(String accountUrn, ObjectUpdate updateObject) throws ConstraintViolationException {
 
         validate(updateObject);
+        checkIdentifiers(updateObject);
 
         Optional<ObjectEntity> entity = findEntity(UuidUtil.getUuidFromAccountUrn(accountUrn), updateObject.getUrn(), updateObject.getObjectUrn());
 
@@ -239,6 +240,16 @@ public class ObjectPersistenceService implements IObjectDao {
         Set<ConstraintViolation<T>> violations = validator.validate(object);
         if (!violations.isEmpty()) {
             throw new ConstraintViolationException("Instance of " + object.getClass().getName() + " violates constraints", violations);
+        }
+    }
+
+    private void checkIdentifiers(ObjectUpdate updateObject) throws IllegalArgumentException {
+        if (StringUtils.isEmpty(updateObject.getUrn()) && StringUtils.isEmpty(updateObject.getObjectUrn())) {
+            throw new IllegalArgumentException(String.format("urn and objectUrn may not be null: %s", updateObject.toString()));
+        }
+
+        if (updateObject.getUrn() != null && updateObject.getObjectUrn() != null) {
+            throw new IllegalArgumentException(String.format("either urn or objectUrn may be defined: %s", updateObject.toString()));
         }
     }
 }

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -1,6 +1,6 @@
 package net.smartcosmos.dao.objects.impl;
 
-import net.smartcosmos.dao.objects.IObjectDao;
+import net.smartcosmos.dao.objects.ObjectDao;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
 import net.smartcosmos.dao.objects.repository.IObjectRepository;
 import net.smartcosmos.dao.objects.util.ObjectsPersistenceUtil;
@@ -29,7 +29,7 @@ import static org.springframework.data.domain.ExampleMatcher.StringMatcher.START
  * @author voor
  */
 @Service
-public class ObjectPersistenceService implements IObjectDao {
+public class ObjectPersistenceService implements ObjectDao {
 
     private final IObjectRepository objectRepository;
     private final ConversionService conversionService;

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -212,12 +212,12 @@ public class ObjectPersistenceService implements ObjectDao {
         if (id != null) {
             entity = objectRepository.findByAccountIdAndId(accountId, id);
 
-            if (entity.isPresent() && !StringUtils.isNotBlank(objectUrn) && !objectUrn.equals(entity.get().getObjectUrn())) {
+            if (entity.isPresent() && StringUtils.isNotBlank(objectUrn) && !objectUrn.equals(entity.get().getObjectUrn())) {
                 throw new IllegalArgumentException("urn and objectUrn do not match");
             }
         }
 
-        if (!StringUtils.isNotBlank(objectUrn)) {
+        if (StringUtils.isNotBlank(objectUrn)) {
             entity = objectRepository.findByAccountIdAndObjectUrn(accountId, objectUrn);
 
             if (entity.isPresent() && id != null && !id.equals(entity.get().getId())) {
@@ -251,11 +251,11 @@ public class ObjectPersistenceService implements ObjectDao {
     }
 
     private void checkIdentifiers(ObjectUpdate updateObject) throws IllegalArgumentException {
-        if (StringUtils.isEmpty(updateObject.getUrn()) && StringUtils.isEmpty(updateObject.getObjectUrn())) {
+        if (StringUtils.isBlank(updateObject.getUrn()) && StringUtils.isBlank(updateObject.getObjectUrn())) {
             throw new IllegalArgumentException(String.format("urn and objectUrn may not be null: %s", updateObject.toString()));
         }
 
-        if (updateObject.getUrn() != null && updateObject.getObjectUrn() != null) {
+        if (StringUtils.isNotBlank(updateObject.getUrn()) && StringUtils.isNotBlank(updateObject.getObjectUrn())) {
             throw new IllegalArgumentException(String.format("either urn or objectUrn may be defined: %s", updateObject.toString()));
         }
     }

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -10,21 +10,19 @@ import net.smartcosmos.dto.objects.ObjectResponse;
 import net.smartcosmos.dto.objects.ObjectUpdate;
 import net.smartcosmos.util.UuidUtil;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionException;
-import org.springframework.util.StringUtils;
 
 import javax.validation.ConstraintViolationException;
-import javax.validation.Validator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -214,12 +212,12 @@ public class ObjectPersistenceService implements ObjectDao {
         if (id != null) {
             entity = objectRepository.findByAccountIdAndId(accountId, id);
 
-            if (entity.isPresent() && !StringUtils.isEmpty(objectUrn) && !objectUrn.equals(entity.get().getObjectUrn())) {
+            if (entity.isPresent() && !StringUtils.isNotBlank(objectUrn) && !objectUrn.equals(entity.get().getObjectUrn())) {
                 throw new IllegalArgumentException("urn and objectUrn do not match");
             }
         }
 
-        if (!StringUtils.isEmpty(objectUrn)) {
+        if (!StringUtils.isNotBlank(objectUrn)) {
             entity = objectRepository.findByAccountIdAndObjectUrn(accountId, objectUrn);
 
             if (entity.isPresent() && id != null && !id.equals(entity.get().getId())) {

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -2,7 +2,7 @@ package net.smartcosmos.dao.objects.impl;
 
 import net.smartcosmos.dao.objects.ObjectDao;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
-import net.smartcosmos.dao.objects.repository.IObjectRepository;
+import net.smartcosmos.dao.objects.repository.ObjectRepository;
 import net.smartcosmos.dao.objects.util.ObjectsPersistenceUtil;
 import net.smartcosmos.dto.objects.ObjectCreate;
 import net.smartcosmos.dto.objects.ObjectResponse;
@@ -31,12 +31,12 @@ import static org.springframework.data.domain.ExampleMatcher.StringMatcher.START
 @Service
 public class ObjectPersistenceService implements ObjectDao {
 
-    private final IObjectRepository objectRepository;
+    private final ObjectRepository objectRepository;
     private final ConversionService conversionService;
     private final Validator validator;
 
     @Autowired
-    public ObjectPersistenceService(IObjectRepository objectRepository,
+    public ObjectPersistenceService(ObjectRepository objectRepository,
             ConversionService conversionService, Validator basicValidator) {
         this.objectRepository = objectRepository;
         this.conversionService = conversionService;
@@ -207,7 +207,7 @@ public class ObjectPersistenceService implements ObjectDao {
     }
 
     /**
-     * Saves an object entity in an {@link IObjectRepository}.
+     * Saves an object entity in an {@link ObjectRepository}.
      *
      * @param objectEntity the object entity to persist
      * @return the persisted object entity

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -7,8 +7,8 @@ import net.smartcosmos.dao.objects.util.ObjectsPersistenceUtil;
 import net.smartcosmos.dto.objects.ObjectCreate;
 import net.smartcosmos.dto.objects.ObjectResponse;
 import net.smartcosmos.dto.objects.ObjectUpdate;
-import org.apache.commons.collections4.MapUtils;
 import net.smartcosmos.util.UuidUtil;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
@@ -18,15 +18,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionException;
 import org.springframework.util.StringUtils;
 
-import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.springframework.data.domain.ExampleMatcher.StringMatcher.STARTING;
@@ -61,7 +55,6 @@ public class ObjectPersistenceService implements IObjectDao {
     @Override
     public Optional<ObjectResponse> update(String accountUrn, ObjectUpdate updateObject) throws ConstraintViolationException {
 
-        validate(updateObject);
         checkIdentifiers(updateObject);
 
         Optional<ObjectEntity> entity = findEntity(UuidUtil.getUuidFromAccountUrn(accountUrn), updateObject.getUrn(), updateObject.getObjectUrn());
@@ -232,14 +225,6 @@ public class ObjectPersistenceService implements IObjectDao {
             } else {
                 throw e;
             }
-        }
-    }
-
-    private <T> void validate(T object) throws ConstraintViolationException {
-
-        Set<ConstraintViolation<T>> violations = validator.validate(object);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException("Instance of " + object.getClass().getName() + " violates constraints", violations);
         }
     }
 

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.TransactionException;
 import org.springframework.util.StringUtils;
 
 import javax.validation.ConstraintViolationException;
-import javax.validation.Validator;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -33,14 +32,12 @@ public class ObjectPersistenceService implements ObjectDao {
 
     private final ObjectRepository objectRepository;
     private final ConversionService conversionService;
-    private final Validator validator;
 
     @Autowired
     public ObjectPersistenceService(ObjectRepository objectRepository,
-            ConversionService conversionService, Validator basicValidator) {
+            ConversionService conversionService) {
         this.objectRepository = objectRepository;
         this.conversionService = conversionService;
-        this.validator = basicValidator;
     }
 
     @Override

--- a/src/main/java/net/smartcosmos/dao/objects/repository/ObjectRepository.java
+++ b/src/main/java/net/smartcosmos/dao/objects/repository/ObjectRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 /**
  * @author voor
  */
-public interface IObjectRepository extends JpaRepository<ObjectEntity, UUID>, QueryByExampleExecutor<ObjectEntity>
+public interface ObjectRepository extends JpaRepository<ObjectEntity, UUID>, QueryByExampleExecutor<ObjectEntity>
 {
 
     Optional<ObjectEntity> findByAccountIdAndObjectUrn(UUID accountId, String objectUrn);

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -4,7 +4,7 @@ import net.smartcosmos.dao.objects.ObjectDao.QueryParameterType;
 import net.smartcosmos.dao.objects.ObjectPersistenceConfig;
 import net.smartcosmos.dao.objects.ObjectPersistenceTestApplication;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
-import net.smartcosmos.dao.objects.repository.IObjectRepository;
+import net.smartcosmos.dao.objects.repository.ObjectRepository;
 import net.smartcosmos.dto.objects.ObjectCreate;
 import net.smartcosmos.dto.objects.ObjectResponse;
 import net.smartcosmos.dto.objects.ObjectUpdate;
@@ -85,7 +85,7 @@ public class ObjectPersistenceServiceTest {
     ObjectPersistenceService objectPersistenceService;
 
     @Autowired
-    IObjectRepository objectRepository;
+    ObjectRepository objectRepository;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -1,6 +1,6 @@
 package net.smartcosmos.dao.objects.impl;
 
-import net.smartcosmos.dao.objects.IObjectDao.QueryParameterType;
+import net.smartcosmos.dao.objects.ObjectDao.QueryParameterType;
 import net.smartcosmos.dao.objects.ObjectPersistenceConfig;
 import net.smartcosmos.dao.objects.ObjectPersistenceTestApplication;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
@@ -35,8 +35,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static net.smartcosmos.dao.objects.IObjectDao.QueryParameterType.MODIFIED_AFTER;
-import static net.smartcosmos.dao.objects.IObjectDao.QueryParameterType.MONIKER_LIKE;
+import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.MODIFIED_AFTER;
+import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.MONIKER_LIKE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -504,7 +504,7 @@ public class ObjectPersistenceServiceTest {
         assertFalse(responseUpdate.isPresent());
     }
 
-    @Test(expected=ConstraintViolationException.class)
+    @Test(expected=IllegalArgumentException.class)
     public void thatUpdateWithoutIdThrowsException() {
 
         String objectUrn = "urn:fakeUrn-update3";
@@ -540,7 +540,7 @@ public class ObjectPersistenceServiceTest {
         Optional<ObjectResponse> responseUpdate = objectPersistenceService.update(accountUrn, update);
     }
 
-    @Test(expected=ConstraintViolationException.class)
+    @Test(expected=IllegalArgumentException.class)
     public void thatUpdateByOverspecifiedIdThrowsException() {
 
         String objectUrn = "urn:fakeUrn-update4";
@@ -578,7 +578,7 @@ public class ObjectPersistenceServiceTest {
         Optional<ObjectResponse> responseUpdate = objectPersistenceService.update(accountUrn, update);
     }
 
-    @Test(expected=ConstraintViolationException.class)
+    @Test(expected=IllegalArgumentException.class)
     public void thatUpdateByOverspecifiedAndConflictingIdThrowsException() {
 
         String objectUrn = "urn:fakeUrn-update5";

--- a/src/test/java/net/smartcosmos/dao/objects/repository/ObjectRepositoryTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/repository/ObjectRepositoryTest.java
@@ -34,7 +34,7 @@ public class ObjectRepositoryTest {
 
     final UUID accountId = UUID.randomUUID();
     @Autowired
-    IObjectRepository objectRepository;
+    ObjectRepository objectRepository;
     private UUID id;
 
     @Before


### PR DESCRIPTION
### What changes were proposed in this pull request?

Since the DTO instances have no constraint annotations anymore, there is nothing to validate. For that reason, the `validate()` method is replaced by `checkIdentifiers()` to verify there's either `urn` or `objectUrn` set for `ObjectUpdate` instances.

Functionality-wise nothing changed, except the exception thrown by the identifier check (now `IllegalArgumentException` instead of `ConstraintViolationException`).

Additionally, the `ObjectDao` without `I` is used, and `IObjectRepository` lost its `I`.
### How is this patch documented?

Code.
### How was this patch tested?

The existing tests are still valid.
#### Depends On
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-objects/pull/14 (already merged)
