### PR TITLE
bug in get?exact=false when searching by URN

### DIFF
--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -109,6 +109,13 @@ public class ObjectPersistenceService implements ObjectDao {
     @Override
     public Optional<ObjectResponse> findByUrn(String accountUrn, String urn) {
 
+        try {
+            UUID uuid = UuidUtil.getUuidFromUrn(urn);
+        }
+        catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+
         Optional<ObjectEntity> entity = objectRepository.findByAccountIdAndId(UuidUtil.getUuidFromAccountUrn(accountUrn),
             UuidUtil.getUuidFromUrn(urn));
 

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -1,5 +1,6 @@
 package net.smartcosmos.dao.objects.impl;
 
+import lombok.extern.slf4j.Slf4j;
 import net.smartcosmos.dao.objects.ObjectDao;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
 import net.smartcosmos.dao.objects.repository.ObjectRepository;
@@ -31,6 +32,7 @@ import static org.springframework.data.jpa.domain.Specifications.where;
 /**
  * @author voor
  */
+@Slf4j
 @Service
 public class ObjectPersistenceService implements ObjectDao {
 
@@ -109,24 +111,23 @@ public class ObjectPersistenceService implements ObjectDao {
     @Override
     public Optional<ObjectResponse> findByUrn(String accountUrn, String urn) {
 
+        Optional<ObjectEntity> entity = Optional.empty();
         try {
             UUID uuid = UuidUtil.getUuidFromUrn(urn);
+            entity = objectRepository.findByAccountIdAndId(UuidUtil.getUuidFromAccountUrn(accountUrn), uuid);
         }
         catch (IllegalArgumentException e) {
-            return Optional.empty();
+            // Optional.empty() will be returned anyway
+            log.warn("Illegal URN submitted: %s by account %s", urn, accountUrn);
         }
-
-        Optional<ObjectEntity> entity = objectRepository.findByAccountIdAndId(UuidUtil.getUuidFromAccountUrn(accountUrn),
-            UuidUtil.getUuidFromUrn(urn));
 
         if (entity.isPresent()) {
             final ObjectResponse response = conversionService.convert(entity.get(),
                 ObjectResponse.class);
             return Optional.ofNullable(response);
         }
-        else {
-            return Optional.empty();
-        }
+        return Optional.empty();
+
     }
 
     /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Uncaught IllegalArgumentException in getByObjectUrn when input string can't be parsed as UUID.
Fixed, now it just returns an Optional.empty().
### How is this patch documented?

Three lines of source code.
### How was this patch tested?

Test added to rdao:GetObjectResourceTest
#### Depends On

Test is in rdao; merge of that pull request follows this one immediately.
