### PR TITLE
Exact flag for query params

### DIFF
--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -166,16 +166,34 @@ public class ObjectPersistenceService implements ObjectDao {
             accountUrnSpecification = searchSpecifications.matchUuid(accountUuid, "accountId");
         }
 
+        // this is only here so direct testing of this method doesn't need to include exact in the queryParameters,
+        // since neither does the GetObjectResource
+        Boolean exact = false;
+        if (MapUtils.getBoolean(queryParameters, QueryParameterType.EXACT) != null)
+        {
+            exact = MapUtils.getBoolean(queryParameters, QueryParameterType.EXACT);
+        }
+
         Specification<ObjectEntity> objectUrnSpecification = null;
         String objectUrnLike = MapUtils.getString(queryParameters, QueryParameterType.OBJECT_URN_LIKE);
         if (objectUrnLike != null) {
-            objectUrnSpecification = searchSpecifications.stringStartsWith(objectUrnLike, QueryParameterType.OBJECT_URN_FIELD_NAME.typeName());
+            if (exact) {
+                objectUrnSpecification = searchSpecifications.stringMatchesExactly(objectUrnLike, QueryParameterType.OBJECT_URN_FIELD_NAME.typeName());
+            }
+            else {
+                objectUrnSpecification = searchSpecifications.stringStartsWith(objectUrnLike, QueryParameterType.OBJECT_URN_FIELD_NAME.typeName());
+            }
         }
 
         Specification<ObjectEntity> nameLikeSpecification = null;
         String nameLike = MapUtils.getString(queryParameters, QueryParameterType.NAME_LIKE);
         if (nameLike != null) {
-            nameLikeSpecification = searchSpecifications.stringStartsWith(nameLike, QueryParameterType.NAME_FIELD_NAME.typeName());
+            if (exact) {
+                nameLikeSpecification = searchSpecifications.stringMatchesExactly(nameLike, QueryParameterType.NAME_FIELD_NAME.typeName());
+            }
+            else {
+                nameLikeSpecification = searchSpecifications.stringStartsWith(nameLike, QueryParameterType.NAME_FIELD_NAME.typeName());
+            }
         }
 
         Specification<ObjectEntity> typeSpecification = null;
@@ -187,7 +205,12 @@ public class ObjectPersistenceService implements ObjectDao {
         Specification<ObjectEntity> monikerLikeSpecification = null;
         String monikerLike = MapUtils.getString(queryParameters, QueryParameterType.MONIKER_LIKE);
         if (monikerLike != null) {
-            monikerLikeSpecification = searchSpecifications.stringStartsWith(monikerLike, QueryParameterType.MONIKER_FIELD_NAME.typeName());
+            if (exact) {
+                monikerLikeSpecification = searchSpecifications.stringMatchesExactly(monikerLike, QueryParameterType.MONIKER_FIELD_NAME.typeName());
+            }
+            else  {
+                monikerLikeSpecification = searchSpecifications.stringStartsWith(monikerLike, QueryParameterType.MONIKER_FIELD_NAME.typeName());
+            }
         }
 
         Specification<ObjectEntity> lastModifedAfterSpecification = null;

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -38,6 +38,7 @@ public class ObjectPersistenceService implements ObjectDao {
 
     private final ObjectRepository objectRepository;
     private final ConversionService conversionService;
+    private final SearchSpecifications<ObjectEntity> searchSpecifications = new SearchSpecifications<ObjectEntity>();
 
     @Autowired
     public ObjectPersistenceService(ObjectRepository objectRepository,
@@ -158,8 +159,6 @@ public class ObjectPersistenceService implements ObjectDao {
      */
     public List<ObjectResponse> findByQueryParameters(String accountUrn, Map<QueryParameterType, Object> queryParameters) {
 
-        SearchSpecifications<ObjectEntity> searchSpecifications = new SearchSpecifications<ObjectEntity>();
-
         Specification<ObjectEntity> accountUrnSpecification = null;
         if (accountUrn != null) {
             UUID accountUuid = UuidUtil.getUuidFromAccountUrn(accountUrn);
@@ -215,7 +214,6 @@ public class ObjectPersistenceService implements ObjectDao {
     private Specification<ObjectEntity> getSearchSpecification(QueryParameterType queryParameterType,
                                                                String query,
                                                                Boolean exact) {
-        SearchSpecifications<ObjectEntity> searchSpecifications = new SearchSpecifications<ObjectEntity>();
         Specification<ObjectEntity> specification = null;
 
         if (StringUtils.isNotBlank(query)) {

--- a/src/main/java/net/smartcosmos/dao/objects/util/SearchSpecifications.java
+++ b/src/main/java/net/smartcosmos/dao/objects/util/SearchSpecifications.java
@@ -51,32 +51,32 @@ public class SearchSpecifications<T>
     //
     // The private methods, which return Predicates
     //
-    private Predicate uuidMatches(Root root, CriteriaQuery<?> query,
+    private Predicate uuidMatches(Root<T> root, CriteriaQuery<?> query,
                                   CriteriaBuilder builder, UUID matches, String queryParameter) {
         return builder.equal(root.get(queryParameter), matches);
     }
 
-    private Predicate stringStartsWith(Root root, CriteriaQuery<?> query,
+    private Predicate stringStartsWith(Root<T> root, CriteriaQuery<?> query,
                                        CriteriaBuilder builder, String startsWith, String queryParameter) {
         return builder.like(root.get(queryParameter), startsWith + "%");
     }
 
-    private Predicate stringEndsWith(Root root, CriteriaQuery<?> query,
+    private Predicate stringEndsWith(Root<T> root, CriteriaQuery<?> query,
                                      CriteriaBuilder builder, String endsWith, String queryParameter) {
         return builder.like(root.get(queryParameter), "%" + endsWith);
     }
 
-    private Predicate stringMatchesExactly(Root root, CriteriaQuery<?> query,
+    private Predicate stringMatchesExactly(Root<T> root, CriteriaQuery<?> query,
                                            CriteriaBuilder builder, String matchesExactly, String queryParameter) {
         return builder.equal(root.get(queryParameter), matchesExactly);
     }
 
-    private Predicate numberLessThan(Root root, CriteriaQuery<?> query,
+    private Predicate numberLessThan(Root<T> root, CriteriaQuery<?> query,
                                      CriteriaBuilder builder, Number numberLessThan, String queryParameter) {
         return builder.lt(root.get(queryParameter), numberLessThan);
     }
 
-    private Predicate numberGreaterThan(Root root, CriteriaQuery<?> query,
+    private Predicate numberGreaterThan(Root<T> root, CriteriaQuery<?> query,
                                         CriteriaBuilder builder, Number numberGreaterThan, String queryParameter) {
         return builder.gt(root.get(queryParameter), numberGreaterThan);
     }

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -35,8 +35,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.EXACT;
 import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.MODIFIED_AFTER;
 import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.MONIKER_LIKE;
+import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.NAME_LIKE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -766,6 +768,46 @@ public class ObjectPersistenceServiceTest {
     }
 
     @Test
+    public void findByQueryParameters_NameLike() throws Exception {
+        populateQueryData();
+
+        Map<QueryParameterType, Object> queryParams = new HashMap<>();
+        int expectedSize = 0;
+        int actualSize = 0;
+
+        expectedSize = 9;
+        queryParams.remove(QueryParameterType.TYPE);
+        queryParams.put(NAME_LIKE, "name");
+        List<ObjectResponse> response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        expectedSize = 5;
+        queryParams.put(QueryParameterType.NAME_LIKE, "name o");
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        expectedSize = 2;
+        queryParams.put(QueryParameterType.NAME_LIKE, "name three");
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        expectedSize = 0;
+        queryParams.put(QueryParameterType.NAME_LIKE, "name z");
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        expectedSize = 0;
+        queryParams.put(QueryParameterType.NAME_LIKE, "ame");
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+    }
+
+    @Test
     public void findByQueryParameters_MonikerLike() throws Exception {
         populateQueryData();
 
@@ -774,7 +816,7 @@ public class ObjectPersistenceServiceTest {
         int actualSize = 0;
 
         expectedSize = 3;
-        queryParams.remove(QueryParameterType.TYPE);
+        queryParams.remove(QueryParameterType.NAME_LIKE);
         queryParams.put(MONIKER_LIKE, "moniker");
         List<ObjectResponse> response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
         actualSize = response.size();

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -732,6 +732,40 @@ public class ObjectPersistenceServiceTest {
         response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
         actualSize = response.size();
         assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+    }
+
+    @Test
+    public void findByQueryParameters_ObjectUrnLike_Exact() throws Exception
+    {
+        populateQueryData();
+        Map<QueryParameterType, Object> queryParams = new HashMap<>();
+        int expectedSize = 0;
+        int actualSize = 0;
+
+        // baseline - no exact flag
+        expectedSize = 9;
+        queryParams.put(QueryParameterType.OBJECT_URN_LIKE, OBJECT_URN_QUERY_PARAMS_0);
+        List<ObjectResponse> response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        // exact = false, which should be a noop
+        expectedSize = 9;
+        queryParams.put(QueryParameterType.OBJECT_URN_LIKE, OBJECT_URN_QUERY_PARAMS_0);
+        queryParams.put(QueryParameterType.EXACT, false);
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        // exact = true should return no elements, since there's no exact match
+        expectedSize = 0;
+        queryParams.put(QueryParameterType.OBJECT_URN_LIKE, OBJECT_URN_QUERY_PARAMS_0);
+        queryParams.put(QueryParameterType.EXACT, true);
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
     }
 
     @Test
@@ -742,9 +776,12 @@ public class ObjectPersistenceServiceTest {
         int expectedSize = 0;
         int actualSize = 0;
 
+        expectedSize = 3;
         queryParams.put(QueryParameterType.TYPE, "type one");
         List<ObjectResponse> response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
-        assertTrue(response.size() == 3);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
 
         // verify that matching of the type field is exact
         expectedSize = 0;
@@ -808,6 +845,43 @@ public class ObjectPersistenceServiceTest {
     }
 
     @Test
+    public void findByQueryParameters_NameLike_Exact() throws Exception
+    {
+        populateQueryData();
+
+        Map<QueryParameterType, Object> queryParams = new HashMap<>();
+        int expectedSize = 0;
+        int actualSize = 0;
+
+        // baseline - no exact flag
+        expectedSize = 9;
+        queryParams.remove(QueryParameterType.TYPE);
+        queryParams.put(NAME_LIKE, "name");
+        List<ObjectResponse> response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        // exact = false, which should be a noop
+        expectedSize = 9;
+        queryParams.remove(QueryParameterType.TYPE);
+        queryParams.put(NAME_LIKE, "name");
+        queryParams.put(QueryParameterType.EXACT, false);
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        // exact = true should return no elements, since there's no exact match
+        expectedSize = 0;
+        queryParams.remove(QueryParameterType.TYPE);
+        queryParams.put(NAME_LIKE, "name");
+        queryParams.put(QueryParameterType.EXACT, true);
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+    }
+
+    @Test
     public void findByQueryParameters_MonikerLike() throws Exception {
         populateQueryData();
 
@@ -848,6 +922,45 @@ public class ObjectPersistenceServiceTest {
     }
 
     @Test
+    public void findByQueryParameters_MonikerLike_Exact() throws Exception
+    {
+        populateQueryData();
+
+        Map<QueryParameterType, Object> queryParams = new HashMap<>();
+        int expectedSize = 0;
+        int actualSize = 0;
+
+        // baseline - no exact flag
+        expectedSize = 3;
+        queryParams.remove(QueryParameterType.NAME_LIKE);
+        queryParams.put(MONIKER_LIKE, "moniker");
+        List<ObjectResponse> response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        // exact = false, which should be a noop
+        expectedSize = 3;
+        queryParams.remove(QueryParameterType.NAME_LIKE);
+        queryParams.put(MONIKER_LIKE, "moniker");
+        queryParams.put(QueryParameterType.EXACT, false);
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+        // exact = true should return no elements, since there's no exact match
+        expectedSize = 0;
+        queryParams.remove(QueryParameterType.NAME_LIKE);
+        queryParams.put(MONIKER_LIKE, "moniker");
+        queryParams.put(QueryParameterType.EXACT, true);
+        response = objectPersistenceService.findByQueryParameters(accountUrn, queryParams);
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+
+
+
+    }
+
+        @Test
     public void findByQueryParameters_LastModified() throws Exception {
 
         final UUID accountUuid = UuidUtil.getNewUuid();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exact flag added to search by query parameters. Not required default is false.
### How is this patch documented?

Javadoc, code commentary, the source code itself. It's not complicated.
### How was this patch tested?

Additional unit tests in objects-jpa:ObjectPersistenseServiceTest
#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-objects/pull/16
