### PR TITLE
Feature/use account urn argument

### DIFF
--- a/src/main/java/net/smartcosmos/dao/objects/converter/ObjectCreateToObjectEntityConverter.java
+++ b/src/main/java/net/smartcosmos/dao/objects/converter/ObjectCreateToObjectEntityConverter.java
@@ -2,10 +2,6 @@ package net.smartcosmos.dao.objects.converter;
 
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
 import net.smartcosmos.dto.objects.ObjectCreate;
-import net.smartcosmos.security.user.SmartCosmosUser;
-import net.smartcosmos.security.user.SmartCosmosUserHolder;
-
-import net.smartcosmos.util.UuidUtil;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistrar;
 import org.springframework.format.FormatterRegistry;
@@ -21,14 +17,10 @@ public class ObjectCreateToObjectEntityConverter
     @Override
     public ObjectEntity convert(ObjectCreate objectCreate) {
 
-        // Retrieve current user.
-        SmartCosmosUser user = SmartCosmosUserHolder.getCurrentUser();
-
         return ObjectEntity.builder()
                 // Required
                 .objectUrn(objectCreate.getObjectUrn()).type(objectCreate.getType())
                 .name(objectCreate.getName())
-                .accountId(UuidUtil.getUuidFromAccountUrn(user.getAccountUrn()))
                 // Optional
                 .activeFlag(objectCreate.getActiveFlag())
                 .description(objectCreate.getDescription())

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -113,12 +113,13 @@ public class ObjectPersistenceService implements ObjectDao {
     @Override
     public Optional<ObjectResponse> findByUrn(String accountUrn, String urn)
     {
-
+        UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
+        
         Optional<ObjectEntity> entity = Optional.empty();
         try
         {
             UUID uuid = UuidUtil.getUuidFromUrn(urn);
-            entity = objectRepository.findByAccountIdAndId(UuidUtil.getUuidFromAccountUrn(accountUrn), uuid);
+            entity = objectRepository.findByAccountIdAndId(accountId, uuid);
         } catch (IllegalArgumentException e)
         {
             // Optional.empty() will be returned anyway
@@ -137,6 +138,8 @@ public class ObjectPersistenceService implements ObjectDao {
     public List<Optional<ObjectResponse>> findByUrns(String accountUrn, Collection<String> urns)
     {
 
+        UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
+
         List<Optional<ObjectResponse>> entities = new ArrayList<>();
 
         for (String urn: urns)
@@ -145,7 +148,7 @@ public class ObjectPersistenceService implements ObjectDao {
             try
             {
                 UUID uuid = UuidUtil.getUuidFromUrn(urn);
-                entity = objectRepository.findByAccountIdAndId(UuidUtil.getUuidFromAccountUrn(accountUrn), uuid);
+                entity = objectRepository.findByAccountIdAndId(accountId, uuid);
 
                 if (entity.isPresent())
                 {

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -1,6 +1,5 @@
 package net.smartcosmos.dao.objects.impl;
 
-import jdk.nashorn.internal.runtime.regexp.joni.constants.OPCode;
 import lombok.extern.slf4j.Slf4j;
 import net.smartcosmos.dao.objects.ObjectDao;
 import net.smartcosmos.dao.objects.domain.ObjectEntity;
@@ -14,7 +13,6 @@ import net.smartcosmos.util.UuidUtil;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.bouncycastle.asn1.cmp.OOBCertHash;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.jpa.domain.Specification;
@@ -32,9 +30,6 @@ import java.util.stream.Collectors;
 
 import static org.springframework.data.jpa.domain.Specifications.where;
 
-/**
- * @author voor
- */
 @Slf4j
 @Service
 public class ObjectPersistenceService implements ObjectDao {
@@ -53,7 +48,10 @@ public class ObjectPersistenceService implements ObjectDao {
     @Override
     public ObjectResponse create(String accountUrn, ObjectCreate createObject) {
 
+        UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
+
         ObjectEntity entity = conversionService.convert(createObject, ObjectEntity.class);
+        entity.setAccountId(accountId);
         entity = persist(entity);
 
         return conversionService.convert(entity, ObjectResponse.class);

--- a/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceService.java
@@ -196,7 +196,7 @@ public class ObjectPersistenceService implements ObjectDao {
     public List<ObjectResponse> findByQueryParameters(String accountUrn, Map<QueryParameterType, Object> queryParameters) {
 
         Specification<ObjectEntity> accountUrnSpecification = null;
-        if (accountUrn != null) {
+        if (StringUtils.isNotBlank(accountUrn)) {
             UUID accountUuid = UuidUtil.getUuidFromAccountUrn(accountUrn);
             accountUrnSpecification = searchSpecifications.matchUuid(accountUuid, "accountId");
         }

--- a/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/objects/impl/ObjectPersistenceServiceTest.java
@@ -27,23 +27,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import javax.validation.ConstraintViolationException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
-import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.EXACT;
-import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.MODIFIED_AFTER;
-import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.MONIKER_LIKE;
-import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.NAME_LIKE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static net.smartcosmos.dao.objects.ObjectDao.QueryParameterType.*;
+import static org.junit.Assert.*;
 
 @SuppressWarnings("Duplicates")
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -116,7 +103,7 @@ public class ObjectPersistenceServiceTest {
             .moniker("moniker").description("description").name("name").type("type")
             .build();
         ObjectResponse response = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, "urn:fakeUrn");
@@ -149,7 +136,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -195,7 +182,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -241,7 +228,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -287,7 +274,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -333,7 +320,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -379,7 +366,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -425,7 +412,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -471,7 +458,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -528,7 +515,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -564,7 +551,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);
@@ -602,7 +589,7 @@ public class ObjectPersistenceServiceTest {
             .build();
 
         ObjectResponse responseCreate = objectPersistenceService
-            .create("urn:account:URN-IN-AUDIT-TRAIL", create);
+            .create(accountUrn, create);
 
         Optional<ObjectEntity> entity = objectRepository
             .findByAccountIdAndObjectUrn(accountId, objectUrn);


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `accountId` isn't retrieved using the `SmartCosmosUserHolder` anymore: 

```
SmartCosmosUser user = SmartCosmosUserHolder.getCurrentUser();
...
UuidUtil.getUuidFromAccountUrn(user.getAccountUrn())
```

Instead, the `accountUrn` passed to the `create()` method is used, like for other calls.

Note that the `IllegalArgumentException` that could occur in case of invalid account URNs is not caught, because the persistence layer doesn't know how to handle that. The other methods are changed so handle that consistently.
### How is this patch documented?

Didn't change.
### How was this patch tested?

Existing unit tests remain valid.
#### Depends On

Nothing.
