### PR TITLE
Feature/objects 828 find all

### DIFF
--- a/src/main/java/net/smartcosmos/dao/things/converter/ConversionServiceAwareConverter.java
+++ b/src/main/java/net/smartcosmos/dao/things/converter/ConversionServiceAwareConverter.java
@@ -1,0 +1,27 @@
+package net.smartcosmos.dao.things.converter;
+
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.ConverterRegistry;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+abstract class ConversionServiceAwareConverter<S, T> implements Converter<S, T> {
+
+    @Inject
+    private ConversionService conversionService;
+
+    protected ConversionService conversionService() {
+        return conversionService;
+    }
+
+    @PostConstruct
+    private void register() {
+        if (conversionService instanceof ConverterRegistry) {
+            ((ConverterRegistry) conversionService).addConverter(this);
+        } else {
+            throw new IllegalStateException("Can't register Converter to ConverterRegistry");
+        }
+    }
+}

--- a/src/main/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverter.java
+++ b/src/main/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverter.java
@@ -17,8 +17,7 @@ import net.smartcosmos.dto.things.ThingResponse;
 
 @Component
 public class SpringDataPageToThingResponsePageConverter
-    extends ConversionServiceAwareConverter<org.springframework.data.domain.Page<ThingEntity>, Page<ThingResponse>>
-    implements FormatterRegistrar {
+    extends ConversionServiceAwareConverter<org.springframework.data.domain.Page<ThingEntity>, Page<ThingResponse>> {
 
     @Inject
     private ConversionService conversionService;
@@ -45,10 +44,5 @@ public class SpringDataPageToThingResponsePageConverter
             .data(data)
             .page(pageInformation)
             .build();
-    }
-
-    @Override
-    public void registerFormatters(FormatterRegistry registry) {
-        registry.addConverter(this);
     }
 }

--- a/src/main/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverter.java
+++ b/src/main/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverter.java
@@ -30,7 +30,7 @@ public class SpringDataPageToThingResponsePageConverter
     public Page<ThingResponse> convert(org.springframework.data.domain.Page<ThingEntity> page) {
 
         PageInformation pageInformation = PageInformation.builder()
-            .number(page.getNumber())
+            .number(page.getNumber() + 1)
             .totalElements(page.getTotalElements())
             .size(page.getNumberOfElements())
             .totalPages(page.getTotalPages())

--- a/src/main/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverter.java
+++ b/src/main/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverter.java
@@ -1,0 +1,54 @@
+package net.smartcosmos.dao.things.converter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.core.convert.ConversionService;
+import org.springframework.format.FormatterRegistrar;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.stereotype.Component;
+
+import net.smartcosmos.dao.things.domain.ThingEntity;
+import net.smartcosmos.dto.things.Page;
+import net.smartcosmos.dto.things.PageInformation;
+import net.smartcosmos.dto.things.ThingResponse;
+
+@Component
+public class SpringDataPageToThingResponsePageConverter
+    extends ConversionServiceAwareConverter<org.springframework.data.domain.Page<ThingEntity>, Page<ThingResponse>>
+    implements FormatterRegistrar {
+
+    @Inject
+    private ConversionService conversionService;
+
+    protected ConversionService conversionService() {
+        return conversionService;
+    }
+
+    @Override
+    public Page<ThingResponse> convert(org.springframework.data.domain.Page<ThingEntity> page) {
+
+        PageInformation pageInformation = PageInformation.builder()
+            .number(page.getNumber())
+            .totalElements(page.getTotalElements())
+            .size(page.getNumberOfElements())
+            .totalPages(page.getTotalPages())
+            .build();
+
+        List<ThingResponse> data = page.getContent().stream()
+            .map(entity -> conversionService.convert(entity, ThingResponse.class))
+            .collect(Collectors.toList());
+
+        return Page.<ThingResponse>builder()
+            .data(data)
+            .page(pageInformation)
+            .build();
+    }
+
+    @Override
+    public void registerFormatters(FormatterRegistry registry) {
+        registry.addConverter(this);
+    }
+}

--- a/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
@@ -127,7 +127,7 @@ public class ThingPersistenceService implements ThingDao {
     }
 
     @Override
-    public Page<ThingResponse> findByType(String tenantUrn, String type, Long page, Integer size) {
+    public Page<ThingResponse> findByType(String tenantUrn, String type, Integer page, Integer size) {
         // TODO: Implement Paging
         return null;
     }

--- a/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
@@ -340,7 +340,7 @@ public class ThingPersistenceService implements ThingDao {
     @Override
     public Page<ThingResponse> findAll(String tenantUrn, Integer page, Integer size) {
 
-        Pageable pageable = new PageRequest(page, size);
+        Pageable pageable = new PageRequest(page - 1, size);
         return findAll(tenantUrn, pageable);
     }
 
@@ -350,7 +350,7 @@ public class ThingPersistenceService implements ThingDao {
         Sort.Direction direction = ThingPersistenceUtil.getSortDirection(sortOrder);
         sortBy = ThingPersistenceUtil.getSortByFieldName(sortBy);
 
-        Pageable pageable = new PageRequest(page, size, direction, sortBy);
+        Pageable pageable = new PageRequest(page - 1, size, direction, sortBy);
 
         return findAll(tenantUrn, pageable);
     }

--- a/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
@@ -1,11 +1,14 @@
 package net.smartcosmos.dao.things.impl;
 
 import lombok.extern.slf4j.Slf4j;
+import net.smartcosmos.dao.things.SortOrder;
 import net.smartcosmos.dao.things.ThingDao;
 import net.smartcosmos.dao.things.domain.ThingEntity;
 import net.smartcosmos.dao.things.repository.ThingRepository;
 import net.smartcosmos.dao.things.util.ThingPersistenceUtil;
 import net.smartcosmos.dao.things.util.UuidUtil;
+import net.smartcosmos.dto.things.Page;
+import net.smartcosmos.dto.things.PageInformation;
 import net.smartcosmos.dto.things.ThingCreate;
 import net.smartcosmos.dto.things.ThingResponse;
 import net.smartcosmos.dto.things.ThingUpdate;
@@ -13,6 +16,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionException;
 
@@ -37,6 +41,8 @@ public class ThingPersistenceService implements ThingDao {
         this.repository = repository;
         this.conversionService = conversionService;
     }
+
+    // region Create
 
     @Override
     public Optional<ThingResponse> create(String tenantUrn, ThingCreate createThing) {
@@ -67,10 +73,9 @@ public class ThingPersistenceService implements ThingDao {
         return Optional.empty();
     }
 
-    private boolean alreadyExists(String tenantUrn, ThingCreate createThing) {
+    // endregion
 
-        return StringUtils.isNotBlank(createThing.getUrn()) && findByUrn(tenantUrn, createThing.getUrn()).isPresent();
-    }
+    // region Update
 
     @Override
     public Optional<ThingResponse> update(String tenantUrn, String type, String urn, ThingUpdate updateThing) throws ConstraintViolationException {
@@ -95,8 +100,12 @@ public class ThingPersistenceService implements ThingDao {
         return Optional.empty();
     }
 
+    // endregion
+
+    // region Find By Type
+
     @Override
-    public List<ThingResponse> findByType(String tenantUrn, String type, Long page, Integer size) {
+    public List<ThingResponse> findByType(String tenantUrn, String type) {
 
         try {
             UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
@@ -110,6 +119,28 @@ public class ThingPersistenceService implements ThingDao {
 
         return new ArrayList<>();
     }
+
+    @Override
+    public List<ThingResponse> findByType(String tenantUrn, String type, SortOrder sortOrder, String sortBy) {
+        // TODO: Implement Sorting
+        return findByType(tenantUrn, type);
+    }
+
+    @Override
+    public Page<ThingResponse> findByType(String tenantUrn, String type, Long page, Integer size) {
+        // TODO: Implement Paging
+        return null;
+    }
+
+    @Override
+    public Page<ThingResponse> findByType(String tenantUrn, String type, Integer page, Integer size, SortOrder sortOrder, String sortBy) {
+        // TODO: Implement Paging and Sorting
+        return null;
+    }
+
+    // endregion
+
+    // region Delete
 
     @Override
     public List<ThingResponse> delete(String tenantUrn, String type, String urn) {
@@ -127,6 +158,10 @@ public class ThingPersistenceService implements ThingDao {
 
         return new ArrayList<>();
     }
+
+    // endregion
+
+    // region Find By Type and URN
 
     @Override
     public Optional<ThingResponse> findByTypeAndUrn(String tenantUrn, String type, String urn) {
@@ -146,28 +181,33 @@ public class ThingPersistenceService implements ThingDao {
         return Optional.empty();
     }
 
-    @Override
-    public List<ThingResponse> findByTypeAndUrnStartsWith(String tenantUrn, String type, String urnStartsWith, Long page, Integer size) {
+    // endregion
 
+    // region Find by Type and URN startsWith
+
+    @Override
+    public List<ThingResponse> findByTypeAndUrnStartsWith(String tenantUrn, String type, String urnStartsWith) {
         throw new UnsupportedOperationException("The database implementation does not support 'startsWith' search for URNs");
     }
 
-    private Optional<ThingResponse> findByUrn(String tenantUrn, String urn) {
-
-        try {
-            UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
-            UUID id = UuidUtil.getUuidFromUrn(urn);
-
-            Optional<ThingEntity> entity = repository.findByIdAndTenantId(id, tenantId);
-
-            return convert(entity);
-        }
-        catch (IllegalArgumentException e) {
-            log.warn("Error processing URNs: Tenant URN '{}' - Thing URN '{}'", tenantUrn, urn);
-        }
-
-        return Optional.empty();
+    @Override
+    public List<ThingResponse> findByTypeAndUrnStartsWith(String tenantUrn, String type, String urnStartsWith, SortOrder sortOrder, String sortBy) {
+        throw new UnsupportedOperationException("The database implementation does not support 'startsWith' search for URNs");
     }
+
+    @Override
+    public Page<ThingResponse> findByTypeAndUrnStartsWith(String tenantUrn, String type, String urnStartsWith, Integer page, Integer size) {
+        throw new UnsupportedOperationException("The database implementation does not support 'startsWith' search for URNs");
+    }
+
+    @Override
+    public Page<ThingResponse> findByTypeAndUrnStartsWith(String tenantUrn, String type, String urnStartsWith, Integer page, Integer size, SortOrder sortOrder, String sortBy) {
+        throw new UnsupportedOperationException("The database implementation does not support 'startsWith' search for URNs");
+    }
+
+    // endregion
+
+    // region Find by URNs
 
     @Override
     public List<ThingResponse> findByUrns(String tenantUrn, Collection<String> urns) {
@@ -199,7 +239,17 @@ public class ThingPersistenceService implements ThingDao {
     }
 
     @Override
-    public List<ThingResponse> findAll(String tenantUrn, Long page, Integer size) {
+    public List<ThingResponse> findByUrns(String tenantUrn, Collection<String> urns, SortOrder sortOrder, String sortBy) {
+        // TODO: Implement Sorting
+        return findByUrns(tenantUrn, urns);
+    }
+
+    // endregion
+
+    // region Find All
+
+    @Override
+    public List<ThingResponse> findAll(String tenantUrn) {
 
         try {
             UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
@@ -212,6 +262,34 @@ public class ThingPersistenceService implements ThingDao {
         }
 
         return new ArrayList<>();
+    }
+
+    @Override
+    public List<ThingResponse> findAll(String tenantUrn, SortOrder sortOrder, String sortBy) {
+        // TODO: Implement Sorting
+        return null;
+    }
+
+    @Override
+    public Page<ThingResponse> findAll(String tenantUrn, Integer page, Integer size) {
+
+        try {
+            UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
+            org.springframework.data.domain.Page<ThingEntity> entityList = repository.findByTenantId(tenantId, new PageRequest(page, size));
+
+            return convert(entityList);
+        }
+        catch (IllegalArgumentException e) {
+            log.warn("Error processing URN: Tenant URN '{}'", tenantUrn);
+        }
+
+        return ThingPersistenceUtil.emptyPage();
+    }
+
+    @Override
+    public Page<ThingResponse> findAll(String tenantUrn, Integer page, Integer size, SortOrder sortOrder, String sortBy) {
+        // TODO: Implement Sorting
+        return findAll(tenantUrn, page, size);
     }
 
     /**
@@ -227,6 +305,10 @@ public class ThingPersistenceService implements ThingDao {
         // done inline here.
         return convert(repository.findAll());
     }
+
+    // endregion
+
+    // region Helper Methods
 
     /**
      * Saves an object entity in an {@link ThingRepository}.
@@ -248,6 +330,28 @@ public class ThingPersistenceService implements ThingDao {
                 throw e;
             }
         }
+    }
+
+    private boolean alreadyExists(String tenantUrn, ThingCreate createThing) {
+
+        return StringUtils.isNotBlank(createThing.getUrn()) && findByUrn(tenantUrn, createThing.getUrn()).isPresent();
+    }
+
+    private Optional<ThingResponse> findByUrn(String tenantUrn, String urn) {
+
+        try {
+            UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
+            UUID id = UuidUtil.getUuidFromUrn(urn);
+
+            Optional<ThingEntity> entity = repository.findByIdAndTenantId(id, tenantId);
+
+            return convert(entity);
+        }
+        catch (IllegalArgumentException e) {
+            log.warn("Error processing URNs: Tenant URN '{}' - Thing URN '{}'", tenantUrn, urn);
+        }
+
+        return Optional.empty();
     }
 
     /**
@@ -278,4 +382,19 @@ public class ThingPersistenceService implements ThingDao {
             .map(o -> conversionService.convert(o, ThingResponse.class))
             .collect(Collectors.toList());
     }
+
+    private Page<ThingResponse> convert(org.springframework.data.domain.Page<ThingEntity> page) {
+        List<ThingResponse> data = convert(page.getContent());
+
+        PageInformation pageInformation = PageInformation.builder()
+            .number(page.getNumber())
+            .totalElements(page.getTotalElements())
+            .size(page.getNumberOfElements())
+            .totalPages(page.getTotalPages())
+            .build();
+
+        return new Page<>(data, pageInformation);
+    }
+
+    // endregion
 }

--- a/src/main/java/net/smartcosmos/dao/things/repository/ThingRepository.java
+++ b/src/main/java/net/smartcosmos/dao/things/repository/ThingRepository.java
@@ -3,6 +3,7 @@ package net.smartcosmos.dao.things.repository;
 import net.smartcosmos.dao.things.domain.ThingEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -24,9 +25,17 @@ public interface ThingRepository extends JpaRepository<ThingEntity, UUID>, Pagin
 
     List<ThingEntity> findByTenantIdAndType(UUID tenantId, String type);
 
+    List<ThingEntity> findByTenantIdAndType(UUID tenantId, String type, Sort sort);
+
+    Page<ThingEntity> findByTenantIdAndType(UUID tenantId, String type, Pageable pageable);
+
     List<ThingEntity> findByTenantId(UUID tenantId);
 
+    List<ThingEntity> findByTenantId(UUID tenantId, Sort sort);
+
     List<ThingEntity> findByIdInAndTenantId(List<UUID> ids, UUID tenantId);
+
+    List<ThingEntity> findByIdInAndTenantId(List<UUID> ids, UUID tenantId, Sort sort);
 
     Page<ThingEntity> findByTenantId(UUID tenantId, Pageable pageable);
 }

--- a/src/main/java/net/smartcosmos/dao/things/repository/ThingRepository.java
+++ b/src/main/java/net/smartcosmos/dao/things/repository/ThingRepository.java
@@ -33,9 +33,10 @@ public interface ThingRepository extends JpaRepository<ThingEntity, UUID>, Pagin
 
     List<ThingEntity> findByTenantId(UUID tenantId, Sort sort);
 
+    Page<ThingEntity> findByTenantId(UUID tenantId, Pageable pageable);
+
     List<ThingEntity> findByIdInAndTenantId(List<UUID> ids, UUID tenantId);
 
     List<ThingEntity> findByIdInAndTenantId(List<UUID> ids, UUID tenantId, Sort sort);
 
-    Page<ThingEntity> findByTenantId(UUID tenantId, Pageable pageable);
 }

--- a/src/main/java/net/smartcosmos/dao/things/repository/ThingRepository.java
+++ b/src/main/java/net/smartcosmos/dao/things/repository/ThingRepository.java
@@ -1,8 +1,11 @@
 package net.smartcosmos.dao.things.repository;
 
 import net.smartcosmos.dao.things.domain.ThingEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface ThingRepository extends JpaRepository<ThingEntity, UUID>, QueryByExampleExecutor<ThingEntity>, JpaSpecificationExecutor<ThingEntity>
+public interface ThingRepository extends JpaRepository<ThingEntity, UUID>, PagingAndSortingRepository<ThingEntity, UUID>, QueryByExampleExecutor<ThingEntity>, JpaSpecificationExecutor<ThingEntity>
 {
     @Transactional
     List<ThingEntity> deleteByIdAndTenantIdAndType(UUID id, UUID tenantId, String type);
@@ -24,4 +27,6 @@ public interface ThingRepository extends JpaRepository<ThingEntity, UUID>, Query
     List<ThingEntity> findByTenantId(UUID tenantId);
 
     List<ThingEntity> findByIdInAndTenantId(List<UUID> ids, UUID tenantId);
+
+    Page<ThingEntity> findByTenantId(UUID tenantId, Pageable pageable);
 }

--- a/src/main/java/net/smartcosmos/dao/things/util/ThingPersistenceUtil.java
+++ b/src/main/java/net/smartcosmos/dao/things/util/ThingPersistenceUtil.java
@@ -1,7 +1,12 @@
 package net.smartcosmos.dao.things.util;
 
 import net.smartcosmos.dao.things.domain.ThingEntity;
+import net.smartcosmos.dto.things.Page;
+import net.smartcosmos.dto.things.PageInformation;
+import net.smartcosmos.dto.things.ThingResponse;
 import net.smartcosmos.dto.things.ThingUpdate;
+
+import java.util.ArrayList;
 
 public class ThingPersistenceUtil {
 
@@ -12,5 +17,10 @@ public class ThingPersistenceUtil {
         }
 
         return thingEntity;
+    }
+
+    public static Page<ThingResponse> emptyPage() {
+
+        return new Page<>(new ArrayList<>(), new PageInformation());
     }
 }

--- a/src/main/java/net/smartcosmos/dao/things/util/ThingPersistenceUtil.java
+++ b/src/main/java/net/smartcosmos/dao/things/util/ThingPersistenceUtil.java
@@ -1,10 +1,13 @@
 package net.smartcosmos.dao.things.util;
 
+import net.smartcosmos.dao.things.SortOrder;
 import net.smartcosmos.dao.things.domain.ThingEntity;
 import net.smartcosmos.dto.things.Page;
 import net.smartcosmos.dto.things.PageInformation;
 import net.smartcosmos.dto.things.ThingResponse;
 import net.smartcosmos.dto.things.ThingUpdate;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.data.domain.Sort;
 
 import java.util.ArrayList;
 
@@ -17,6 +20,63 @@ public class ThingPersistenceUtil {
         }
 
         return thingEntity;
+    }
+
+    public static String normalizeFieldName(String fieldName) {
+
+        if (StringUtils.equalsIgnoreCase("urn", fieldName)) {
+            return "id";
+        }
+
+        if (StringUtils.equalsIgnoreCase("type", fieldName)) {
+            return "type";
+        }
+
+        if (StringUtils.equalsIgnoreCase("tenantUrn", fieldName)) {
+            return "tenantId";
+        }
+
+        if (StringUtils.equalsIgnoreCase("created", fieldName)) {
+            return "created";
+        }
+
+        if (StringUtils.equalsIgnoreCase("lastModified", fieldName)) {
+            return "lastModified";
+        }
+
+        if (StringUtils.equalsIgnoreCase("active", fieldName)) {
+            return "active";
+        }
+
+        return fieldName;
+    }
+
+    public static boolean isThingEntityField(String fieldName) {
+
+        try {
+            ThingEntity.class.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static String getSortByFieldName(String sortBy) {
+        sortBy = ThingPersistenceUtil.normalizeFieldName(sortBy);
+        if (StringUtils.isBlank(sortBy) || !ThingPersistenceUtil.isThingEntityField(sortBy)) {
+            sortBy = "id";
+        }
+        return sortBy;
+    }
+
+    public static Sort.Direction getSortDirection(SortOrder sortOrder) {
+        Sort.Direction direction = Sort.DEFAULT_DIRECTION;
+        switch (sortOrder) {
+            case ASC: direction = Sort.Direction.ASC; break;
+            case DESC: direction = Sort.Direction.DESC; break;
+        }
+        return direction;
     }
 
     public static Page<ThingResponse> emptyPage() {

--- a/src/main/java/net/smartcosmos/dao/things/util/ThingPersistenceUtil.java
+++ b/src/main/java/net/smartcosmos/dao/things/util/ThingPersistenceUtil.java
@@ -24,7 +24,7 @@ public class ThingPersistenceUtil {
 
     public static String normalizeFieldName(String fieldName) {
 
-        if (StringUtils.equalsIgnoreCase("urn", fieldName)) {
+        if (StringUtils.equalsIgnoreCase("urn", fieldName) || StringUtils.equalsIgnoreCase("id", fieldName)) {
             return "id";
         }
 
@@ -32,7 +32,7 @@ public class ThingPersistenceUtil {
             return "type";
         }
 
-        if (StringUtils.equalsIgnoreCase("tenantUrn", fieldName)) {
+        if (StringUtils.equalsIgnoreCase("tenantUrn", fieldName) || StringUtils.equalsIgnoreCase("tenantId", fieldName)) {
             return "tenantId";
         }
 

--- a/src/main/java/net/smartcosmos/dao/things/util/ThingPersistenceUtil.java
+++ b/src/main/java/net/smartcosmos/dao/things/util/ThingPersistenceUtil.java
@@ -13,6 +13,13 @@ import java.util.ArrayList;
 
 public class ThingPersistenceUtil {
 
+    /**
+     * Merges a {@link ThingEntity} instance with the content of a {@link ThingUpdate} instance.
+     *
+     * @param thingEntity the existing Thing
+     * @param updateThing the update content
+     * @return the merged entity
+     */
     public static ThingEntity merge(ThingEntity thingEntity, ThingUpdate updateThing) {
 
         if (updateThing.getActive() != null) {
@@ -22,6 +29,13 @@ public class ThingPersistenceUtil {
         return thingEntity;
     }
 
+    /**
+     * Transforms a field name for a sorted query to a valid case-sensitive field name that exists in the entity class.
+     * Returns the input field name, if it does not exist in the entity class.
+     *
+     * @param fieldName the input field name
+     * @return the case-corrected field name
+     */
     public static String normalizeFieldName(String fieldName) {
 
         if (StringUtils.equalsIgnoreCase("urn", fieldName) || StringUtils.equalsIgnoreCase("id", fieldName)) {
@@ -51,6 +65,12 @@ public class ThingPersistenceUtil {
         return fieldName;
     }
 
+    /**
+     * Checks if a given field name exists in {@link ThingEntity}.
+     *
+     * @param fieldName the field name
+     * @return {@code true} if the field exists
+     */
     public static boolean isThingEntityField(String fieldName) {
 
         try {
@@ -62,6 +82,13 @@ public class ThingPersistenceUtil {
         return true;
     }
 
+    /**
+     * Gets a valid field name for a {@code sortBy} query in the {@link ThingEntity} data base.
+     * The input field name is case-corrected and replaced by {@code id} if it does not exist in the entity class.
+     *
+     * @param sortBy the input field name
+     * @return the case-corrected field name if it exists, {@code id} otherwise
+     */
     public static String getSortByFieldName(String sortBy) {
         sortBy = ThingPersistenceUtil.normalizeFieldName(sortBy);
         if (StringUtils.isBlank(sortBy) || !ThingPersistenceUtil.isThingEntityField(sortBy)) {
@@ -70,6 +97,12 @@ public class ThingPersistenceUtil {
         return sortBy;
     }
 
+    /**
+     * Converts the {@link SortOrder} value to a Spring-compatible {@link org.springframework.data.domain.Sort.Direction} sort direction.
+     *
+     * @param sortOrder the sort order
+     * @return the Spring sort direction
+     */
     public static Sort.Direction getSortDirection(SortOrder sortOrder) {
         Sort.Direction direction = Sort.DEFAULT_DIRECTION;
         switch (sortOrder) {
@@ -79,6 +112,11 @@ public class ThingPersistenceUtil {
         return direction;
     }
 
+    /**
+     * Creates an empty {@link Page<ThingResponse>} instance.
+     *
+     * @return the empty page
+     */
     public static Page<ThingResponse> emptyPage() {
 
         return new Page<>(new ArrayList<>(), new PageInformation());

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -570,9 +570,9 @@ public class ThingPersistenceServiceTest {
         assertEquals(12, page1.getPage().getTotalElements());
         assertEquals(1, page1.getPage().getNumber());
 
-        assertEquals(TYPE_ONE, page1.getData().get(0));
-        assertEquals(TYPE_ONE, page1.getData().get(1));
-        assertEquals(TYPE_ONE, page1.getData().get(2));
+        assertEquals(TYPE_ONE, page1.getData().get(0).getType());
+        assertEquals(TYPE_ONE, page1.getData().get(1).getType());
+        assertEquals(TYPE_ONE, page1.getData().get(2).getType());
 
         Page<ThingResponse> page2 = persistenceService.findAll(tenantUrn, 2, 3, SortOrder.ASC, "type");
 
@@ -582,11 +582,11 @@ public class ThingPersistenceServiceTest {
         assertEquals(3, page2.getPage().getSize());
         assertEquals(4, page2.getPage().getTotalPages());
         assertEquals(12, page2.getPage().getTotalElements());
-        assertEquals(1, page2.getPage().getNumber());
+        assertEquals(2, page2.getPage().getNumber());
 
-        assertEquals(TYPE_TWO, page2.getData().get(0));
-        assertEquals(TYPE_TWO, page2.getData().get(1));
-        assertEquals(TYPE_TWO, page2.getData().get(2));
+        assertEquals(TYPE_TWO, page2.getData().get(0).getType());
+        assertEquals(TYPE_TWO, page2.getData().get(1).getType());
+        assertEquals(TYPE_TWO, page2.getData().get(2).getType());
     }
 
     // endregion

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -279,7 +279,7 @@ public class ThingPersistenceServiceTest {
         int expectedSize = 3;
         int actualSize = 0;
 
-        List<ThingResponse> response = persistenceService.findByType(tenantUrn, TYPE_ONE, 0L, 100);
+        List<ThingResponse> response = persistenceService.findByType(tenantUrn, TYPE_ONE);
 
         actualSize = response.size();
         assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -477,6 +477,82 @@ public class ThingPersistenceServiceTest {
 
     // endregion
 
+    // region Find All
+
+    @Test
+    public void testFindAll() throws Exception {
+
+        populateData();
+
+        int expectedSize = 12;
+        int actualSize = 0;
+
+        List<ThingResponse> response = persistenceService.findAll(tenantUrn);
+
+        assertFalse(response.isEmpty());
+
+        actualSize = response.size();
+        assertTrue("Expected " + expectedSize + " but received " + actualSize, actualSize == expectedSize);
+    }
+
+    @Test
+    public void testFindAllSortingAsc() throws Exception {
+
+        populateData();
+
+        List<ThingResponse> response = persistenceService.findAll(tenantUrn, SortOrder.ASC, "type");
+
+        assertFalse(response.isEmpty());
+        assertEquals(TYPE_ONE, response.get(0).getType());
+        assertEquals(TYPE_ONE, response.get(1).getType());
+        assertEquals(TYPE_ONE, response.get(2).getType());
+        assertEquals(TYPE_TWO, response.get(3).getType());
+        assertEquals(TYPE_TWO, response.get(4).getType());
+        assertEquals(TYPE_TWO, response.get(5).getType());
+        assertEquals(WHATEVER, response.get(6).getType());
+        assertEquals(WHATEVER, response.get(7).getType());
+        assertEquals(WHATEVER, response.get(8).getType());
+        assertEquals(WHATEVER, response.get(9).getType());
+        assertEquals(WHATEVER, response.get(10).getType());
+        assertEquals(WHATEVER, response.get(11).getType());
+    }
+
+    @Test
+    public void testFindAllSortingDesc() throws Exception {
+
+        populateData();
+
+        List<ThingResponse> response = persistenceService.findAll(tenantUrn, SortOrder.DESC, "type");
+
+        assertFalse(response.isEmpty());
+        assertEquals(WHATEVER, response.get(0).getType());
+        assertEquals(WHATEVER, response.get(1).getType());
+        assertEquals(WHATEVER, response.get(2).getType());
+        assertEquals(WHATEVER, response.get(3).getType());
+        assertEquals(WHATEVER, response.get(4).getType());
+        assertEquals(WHATEVER, response.get(5).getType());
+        assertEquals(TYPE_TWO, response.get(6).getType());
+        assertEquals(TYPE_TWO, response.get(7).getType());
+        assertEquals(TYPE_TWO, response.get(8).getType());
+        assertEquals(TYPE_ONE, response.get(9).getType());
+        assertEquals(TYPE_ONE, response.get(10).getType());
+        assertEquals(TYPE_ONE, response.get(11).getType());
+    }
+
+    @Test
+    public void testFindAllPaging() throws Exception {
+
+        populateData();
+    }
+
+    @Test
+    public void testFinallPagingAndSorting() throws Exception {
+
+        populateData();
+    }
+
+    // endregion
+
     // region Helper Methods
 
     private void populateData() throws Exception {

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -300,7 +300,7 @@ public class ThingPersistenceServiceTest {
         long expectedTotalSize = 6;
         long actualTotalSize = 0;
 
-        Page<ThingResponse> response = persistenceService.findByType(tenantUrn, WHATEVER, 0, 3);
+        Page<ThingResponse> response = persistenceService.findByType(tenantUrn, WHATEVER, 1, 3);
 
         assertNotNull(response);
         assertNotNull(response.getData());
@@ -543,12 +543,50 @@ public class ThingPersistenceServiceTest {
     public void testFindAllPaging() throws Exception {
 
         populateData();
+
+        Page<ThingResponse> response = persistenceService.findAll(tenantUrn, 1, 3);
+
+        assertFalse(response.getData().isEmpty());
+        assertEquals(3, response.getData().size());
+
+        assertEquals(3, response.getPage().getSize());
+        assertEquals(4, response.getPage().getTotalPages());
+        assertEquals(12, response.getPage().getTotalElements());
+        assertEquals(1, response.getPage().getNumber());
     }
 
     @Test
     public void testFinallPagingAndSorting() throws Exception {
 
         populateData();
+
+        Page<ThingResponse> page1 = persistenceService.findAll(tenantUrn, 1, 3, SortOrder.ASC, "type");
+
+        assertFalse(page1.getData().isEmpty());
+        assertEquals(3, page1.getData().size());
+
+        assertEquals(3, page1.getPage().getSize());
+        assertEquals(4, page1.getPage().getTotalPages());
+        assertEquals(12, page1.getPage().getTotalElements());
+        assertEquals(1, page1.getPage().getNumber());
+
+        assertEquals(TYPE_ONE, page1.getData().get(0));
+        assertEquals(TYPE_ONE, page1.getData().get(1));
+        assertEquals(TYPE_ONE, page1.getData().get(2));
+
+        Page<ThingResponse> page2 = persistenceService.findAll(tenantUrn, 2, 3, SortOrder.ASC, "type");
+
+        assertFalse(page2.getData().isEmpty());
+        assertEquals(3, page2.getData().size());
+
+        assertEquals(3, page2.getPage().getSize());
+        assertEquals(4, page2.getPage().getTotalPages());
+        assertEquals(12, page2.getPage().getTotalElements());
+        assertEquals(1, page2.getPage().getNumber());
+
+        assertEquals(TYPE_TWO, page2.getData().get(0));
+        assertEquals(TYPE_TWO, page2.getData().get(1));
+        assertEquals(TYPE_TWO, page2.getData().get(2));
     }
 
     // endregion

--- a/src/test/java/net/smartcosmos/dao/things/repository/ThingRepositoryTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/repository/ThingRepositoryTest.java
@@ -1,7 +1,7 @@
 package net.smartcosmos.dao.things.repository;
 
-import net.smartcosmos.dao.things.ThingsPersistenceTestApplication;
 import net.smartcosmos.dao.things.ThingPersistenceConfig;
+import net.smartcosmos.dao.things.ThingsPersistenceTestApplication;
 import net.smartcosmos.dao.things.domain.ThingEntity;
 import org.junit.After;
 import org.junit.Before;
@@ -10,6 +10,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -104,5 +106,31 @@ public class ThingRepositoryTest {
 
         assertEquals(1, entityList.size());
         assertEquals(id, entityList.get(0).getId());
+    }
+
+    @Test
+    public void findByTenantIdPageable() throws Exception {
+
+        final UUID tenantId = UUID.randomUUID();
+        final int entityCount = 30;
+        List<UUID> ids = new ArrayList<>();
+
+        for (int i = 0; i < entityCount; i++) {
+            UUID id = UUID.randomUUID();
+            ids.add(id);
+
+            ThingEntity entity = repository
+                .save(ThingEntity.builder()
+                    .id(id)
+                    .tenantId(tenantId)
+                    .type(type).build());
+        }
+
+        Page<ThingEntity> entityList = repository.findByTenantId(tenantId, new PageRequest(0, 1));
+        assertFalse(entityList.getContent().isEmpty());
+
+        assertEquals(1, entityList.getContent().size());
+        assertTrue(ids.contains(entityList.getContent().get(0).getId()));
+        assertEquals(entityCount, entityList.getTotalElements());
     }
 }

--- a/src/test/java/net/smartcosmos/dao/things/repository/ThingRepositoryTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/repository/ThingRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -31,6 +32,7 @@ import static org.junit.Assert.assertTrue;
  * testing.tenantId
  * @author voor
  */
+@SuppressWarnings("Duplicates")
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = { ThingsPersistenceTestApplication.class,
         ThingPersistenceConfig.class })
@@ -132,5 +134,142 @@ public class ThingRepositoryTest {
         assertEquals(1, entityList.getContent().size());
         assertTrue(ids.contains(entityList.getContent().get(0).getId()));
         assertEquals(entityCount, entityList.getTotalElements());
+    }
+
+    @Test
+    public void findByTenantIdPageableAndSortableAsc() throws Exception {
+
+        final UUID tenantId = UUID.randomUUID();
+        final int entityCount = 30;
+        List<UUID> ids = new ArrayList<>();
+        final String typeA = "A";
+        final String typeB = "B";
+
+        for (int i = 0; i < entityCount; i++) {
+            UUID id = UUID.randomUUID();
+            ids.add(id);
+
+            String type;
+            if (i < 15) {
+                type = typeA;
+            } else {
+                type = typeB;
+            }
+
+            ThingEntity entity = repository
+                .save(ThingEntity.builder()
+                    .id(id)
+                    .type(type)
+                    .tenantId(tenantId)
+                    .build());
+        }
+
+        Page<ThingEntity> page1 = repository.findByTenantId(tenantId, new PageRequest(0, 5, Sort.Direction.ASC, "type"));
+        assertFalse(page1.getContent().isEmpty());
+
+        assertEquals(5, page1.getContent().size());
+        assertTrue(ids.subList(0, 15).contains(page1.getContent().get(0).getId()));
+        assertTrue(ids.subList(0, 15).contains(page1.getContent().get(4).getId()));
+        assertEquals(typeA, page1.getContent().get(0).getType());
+        assertEquals(typeA, page1.getContent().get(4).getType());
+        assertEquals(entityCount, page1.getTotalElements());
+
+        Page<ThingEntity> page6 = repository.findByTenantId(tenantId, new PageRequest(5, 5, Sort.Direction.ASC, "type"));
+        assertFalse(page6.getContent().isEmpty());
+
+        assertEquals(5, page6.getContent().size());
+        assertTrue(ids.subList(15, 29).contains(page6.getContent().get(0).getId()));
+        assertTrue(ids.subList(15, 29).contains(page6.getContent().get(4).getId()));
+        assertEquals(typeB, page6.getContent().get(0).getType());
+        assertEquals(typeB, page6.getContent().get(4).getType());
+        assertEquals(entityCount, page6.getTotalElements());
+    }
+
+    @Test
+    public void findByTenantIdPageableAndSortableDesc() throws Exception {
+
+        final UUID tenantId = UUID.randomUUID();
+        final int entityCount = 30;
+        List<UUID> ids = new ArrayList<>();
+        final String typeA = "A";
+        final String typeB = "B";
+
+        for (int i = 0; i < entityCount; i++) {
+            UUID id = UUID.randomUUID();
+            ids.add(id);
+
+            String type;
+            if (i < 15) {
+                type = typeA;
+            } else {
+                type = typeB;
+            }
+
+            ThingEntity entity = repository
+                .save(ThingEntity.builder()
+                    .id(id)
+                    .type(type)
+                    .tenantId(tenantId)
+                    .build());
+        }
+
+        Page<ThingEntity> page1 = repository.findByTenantId(tenantId, new PageRequest(0, 5, Sort.Direction.DESC, "type"));
+        assertFalse(page1.getContent().isEmpty());
+
+        assertEquals(5, page1.getContent().size());
+        assertTrue(ids.subList(15, 29).contains(page1.getContent().get(0).getId()));
+        assertTrue(ids.subList(15, 29).contains(page1.getContent().get(4).getId()));
+        assertEquals(typeB, page1.getContent().get(0).getType());
+        assertEquals(typeB, page1.getContent().get(4).getType());
+        assertEquals(entityCount, page1.getTotalElements());
+
+        Page<ThingEntity> page6 = repository.findByTenantId(tenantId, new PageRequest(5, 5, Sort.Direction.DESC, "type"));
+        assertFalse(page6.getContent().isEmpty());
+
+        assertEquals(5, page6.getContent().size());
+        assertTrue(ids.subList(0, 15).contains(page6.getContent().get(0).getId()));
+        assertTrue(ids.subList(0, 15).contains(page6.getContent().get(4).getId()));
+        assertEquals(typeA, page6.getContent().get(0).getType());
+        assertEquals(typeA, page6.getContent().get(4).getType());
+        assertEquals(entityCount, page6.getTotalElements());
+    }
+
+    @Test
+    public void findByTenantIdSortableDesc() throws Exception {
+
+        final UUID tenantId = UUID.randomUUID();
+        final int entityCount = 30;
+        List<UUID> ids = new ArrayList<>();
+        final String typeA = "A";
+        final String typeB = "B";
+
+        for (int i = 0; i < entityCount; i++) {
+            UUID id = UUID.randomUUID();
+            ids.add(id);
+
+            String type;
+            if (i < 15) {
+                type = typeA;
+            } else {
+                type = typeB;
+            }
+
+            ThingEntity entity = repository
+                .save(ThingEntity.builder()
+                    .id(id)
+                    .type(type)
+                    .tenantId(tenantId)
+                    .build());
+        }
+
+        List<ThingEntity> entityList = repository.findByTenantId(tenantId, new Sort(Sort.Direction.DESC, "type"));
+        assertFalse(entityList.isEmpty());
+
+        assertEquals(entityCount, entityList.size());
+        assertEquals(typeB, entityList.get(0).getType());
+        assertEquals(typeB, entityList.get(14).getType());
+
+        assertEquals(typeA, entityList.get(15).getType());
+        assertEquals(typeA, entityList.get(29).getType());
     }
 }

--- a/src/test/java/net/smartcosmos/dao/things/util/ThingPersistenceUtilTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/util/ThingPersistenceUtilTest.java
@@ -1,0 +1,53 @@
+package net.smartcosmos.dao.things.util;
+
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("Duplicates")
+public class ThingPersistenceUtilTest {
+
+    @Test
+    public void isEntityFieldValid() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        assertTrue(ThingPersistenceUtil.isThingEntityField("id"));
+        assertTrue(ThingPersistenceUtil.isThingEntityField("tenantId"));
+        assertTrue(ThingPersistenceUtil.isThingEntityField("type"));
+        assertTrue(ThingPersistenceUtil.isThingEntityField("active"));
+        assertTrue(ThingPersistenceUtil.isThingEntityField("created"));
+        assertTrue(ThingPersistenceUtil.isThingEntityField("lastModified"));
+    }
+
+    @Test
+    public void isEntityFieldInValid() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        assertFalse(ThingPersistenceUtil.isThingEntityField("name"));
+        assertFalse(ThingPersistenceUtil.isThingEntityField("description"));
+        assertFalse(ThingPersistenceUtil.isThingEntityField("moniker"));
+    }
+
+    @Test
+    public void normalizeFieldNameUrn() {
+        assertEquals("id", ThingPersistenceUtil.normalizeFieldName("urn"));
+        assertEquals("id", ThingPersistenceUtil.normalizeFieldName("Urn"));
+        assertEquals("id", ThingPersistenceUtil.normalizeFieldName("URN"));
+
+        assertEquals("id", ThingPersistenceUtil.normalizeFieldName("id"));
+        assertEquals("id", ThingPersistenceUtil.normalizeFieldName("Id"));
+        assertEquals("id", ThingPersistenceUtil.normalizeFieldName("ID"));
+    }
+
+    @Test
+    public void normalizeFieldNameTenantUrn() {
+        assertEquals("tenantId", ThingPersistenceUtil.normalizeFieldName("tenanturn"));
+        assertEquals("tenantId", ThingPersistenceUtil.normalizeFieldName("TenantUrn"));
+        assertEquals("tenantId", ThingPersistenceUtil.normalizeFieldName("TENANTURN"));
+
+        assertEquals("tenantId", ThingPersistenceUtil.normalizeFieldName("tenantid"));
+        assertEquals("tenantId", ThingPersistenceUtil.normalizeFieldName("TenantId"));
+        assertEquals("tenantId", ThingPersistenceUtil.normalizeFieldName("TENANTID"));
+    }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
- adds `findByType()` and `findAll()` implementations
- introduces an abstract converter class that allows for "nested conversion" (access to the conversion service from within a converter), as needed for the page conversion
- adds paging and sorting capabilities to most methods
### How is this patch documented?

Code and Javadoc.
### How was this patch tested?

Unit tests.
#### Depends On
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-objects/pull/37
