### PR TITLE
Bugfix/objects 887 already exists ignores type

### DIFF
--- a/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
@@ -407,16 +407,16 @@ public class ThingPersistenceService implements ThingDao {
 
     private boolean alreadyExists(String tenantUrn, ThingCreate createThing) {
 
-        return StringUtils.isNotBlank(createThing.getUrn()) && findByUrn(tenantUrn, createThing.getUrn()).isPresent();
+        return StringUtils.isNotBlank(createThing.getUrn()) && findByUrnAndType(tenantUrn, createThing.getUrn(), createThing.getType()).isPresent();
     }
 
-    private Optional<ThingResponse> findByUrn(String tenantUrn, String urn) {
+    private Optional<ThingResponse> findByUrnAndType(String tenantUrn, String urn, String type) {
 
         try {
             UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
             UUID id = UuidUtil.getUuidFromUrn(urn);
 
-            Optional<ThingEntity> entity = repository.findByIdAndTenantId(id, tenantId);
+            Optional<ThingEntity> entity = repository.findByIdAndTenantIdAndTypeIgnoreCase(id, tenantId, type);
 
             return convert(entity);
         }

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -162,6 +162,29 @@ public class ThingPersistenceServiceTest {
         assertFalse(response2.isPresent());
     }
 
+    @Test
+    public void thatDuplicateIdDifferentTypeSucceeds() {
+
+        final String uuid = "238978cb-c279-47e6-a553-92f2c372ae1d";
+        final String urn = "urn:thing:uuid:" + uuid;
+
+        ThingCreate create1 = ThingCreate.builder()
+            .urn(urn)
+            .type("type")
+            .build();
+        Optional<ThingResponse> response1 = persistenceService
+            .create(tenantUrn, create1);
+        assertTrue(response1.isPresent());
+
+        ThingCreate create2 = ThingCreate.builder()
+            .urn(urn)
+            .type("type2")
+            .build();
+        Optional<ThingResponse> response2 = persistenceService
+            .create(tenantUrn, create2);
+        assertTrue(response2.isPresent());
+    }
+
     // endregion
 
     // region Update

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -165,7 +165,7 @@ public class ThingPersistenceServiceTest {
     @Test
     public void thatDuplicateIdDifferentTypeSucceeds() {
 
-        final String uuid = "238978cb-c279-47e6-a553-92f2c372ae1d";
+        final String uuid = "06ee2f2f-eb93-4089-98c0-cc732b1837ba";
         final String urn = "urn:thing:uuid:" + uuid;
 
         ThingCreate create1 = ThingCreate.builder()


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `type` field is added to the `alreadyExists()` method.
### How is this patch documented?

Code.
### How was this patch tested?

There is an additional unit test that checks if it is possible to create two things with the same URN, but different types.
#### Depends On

Nothing else.
