### PR TITLE
Bugfix/objects 933

### DIFF
--- a/src/main/java/net/smartcosmos/dao/things/domain/ThingEntity.java
+++ b/src/main/java/net/smartcosmos/dao/things/domain/ThingEntity.java
@@ -31,7 +31,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @EntityListeners({ AuditingEntityListener.class })
-@Table(name = "thing", uniqueConstraints = @UniqueConstraint(columnNames = { "id", "tenantId" }) )
+@Table(name = "thing", uniqueConstraints = @UniqueConstraint(columnNames = { "id", "tenantId", "type" }) )
 public class ThingEntity implements Serializable {
 
     private static final int UUID_LENGTH = 16;

--- a/src/main/java/net/smartcosmos/dao/things/domain/ThingEntity.java
+++ b/src/main/java/net/smartcosmos/dao/things/domain/ThingEntity.java
@@ -9,10 +9,10 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.Id;
+import javax.persistence.IdClass;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -28,10 +28,11 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity(name = "thing")
+@IdClass(ThingId.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @EntityListeners({ AuditingEntityListener.class })
-@Table(name = "thing", uniqueConstraints = @UniqueConstraint(columnNames = { "id", "tenantId", "type" }) )
+@Table(name = "thing")
 public class ThingEntity implements Serializable {
 
     private static final int UUID_LENGTH = 16;
@@ -50,11 +51,13 @@ public class ThingEntity implements Serializable {
     @Column(name = "id", length = UUID_LENGTH)
     private UUID id;
 
+    @Id
     @NotEmpty
     @Size(max = TYPE_LENGTH)
     @Column(name = "type", length = TYPE_LENGTH, nullable = false, updatable = false)
     private String type;
 
+    @Id
     @NotNull
     @Type(type = "uuid-binary")
     @Column(name = "tenantId", length = UUID_LENGTH, nullable = false, updatable = false)

--- a/src/main/java/net/smartcosmos/dao/things/domain/ThingId.java
+++ b/src/main/java/net/smartcosmos/dao/things/domain/ThingId.java
@@ -1,0 +1,16 @@
+package net.smartcosmos.dao.things.domain;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ThingId implements Serializable {
+
+    private UUID id;
+    private String type;
+    private UUID tenantId;
+}

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -598,7 +598,7 @@ public class ThingPersistenceServiceTest {
     }
 
     @Test
-    public void testFinallPagingAndSorting() throws Exception {
+    public void testFindAllPagingAndSorting() throws Exception {
 
         populateData();
 

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -162,31 +162,33 @@ public class ThingPersistenceServiceTest {
 
         final String uuid = "06ee2f2f-eb93-4089-98c0-cc732b1837ba";
         final String urn = "urn:thing:uuid:" + uuid;
+        final String type1 = "type1";
+        final String type2 = "type2";
 
         ThingCreate create1 = ThingCreate.builder()
             .urn(urn)
-            .type("type")
+            .type(type1)
             .build();
         Optional<ThingResponse> createResponse1 = persistenceService
             .create(tenantUrn, create1);
         assertTrue(createResponse1.isPresent());
-        assertEquals("type1", createResponse1.get().getType());
+        assertEquals(type1, createResponse1.get().getType());
         assertEquals(urn, createResponse1.get().getUrn());
 
-        Optional<ThingResponse> persistResponse1 = persistenceService.findByTypeAndUrn(tenantUrn, "type1", urn);
+        Optional<ThingResponse> persistResponse1 = persistenceService.findByTypeAndUrn(tenantUrn, type1, urn);
         assertTrue(persistResponse1.isPresent());
 
         ThingCreate create2 = ThingCreate.builder()
             .urn(urn)
-            .type("type2")
+            .type(type2)
             .build();
         Optional<ThingResponse> createResponse2 = persistenceService
             .create(tenantUrn, create2);
         assertTrue(createResponse2.isPresent());
-        assertEquals("type2", createResponse2.get().getType());
+        assertEquals(type2, createResponse2.get().getType());
         assertEquals(urn, createResponse2.get().getUrn());
 
-        Optional<ThingResponse> persistResponse2 = persistenceService.findByTypeAndUrn(tenantUrn, "type2", urn);
+        Optional<ThingResponse> persistResponse2 = persistenceService.findByTypeAndUrn(tenantUrn, type2, urn);
         assertTrue(persistResponse2.isPresent());
     }
 

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -167,17 +167,27 @@ public class ThingPersistenceServiceTest {
             .urn(urn)
             .type("type")
             .build();
-        Optional<ThingResponse> response1 = persistenceService
+        Optional<ThingResponse> createResponse1 = persistenceService
             .create(tenantUrn, create1);
-        assertTrue(response1.isPresent());
+        assertTrue(createResponse1.isPresent());
+        assertEquals("type1", createResponse1.get().getType());
+        assertEquals(urn, createResponse1.get().getUrn());
+
+        Optional<ThingResponse> persistResponse1 = persistenceService.findByTypeAndUrn(tenantUrn, "type1", urn);
+        assertTrue(persistResponse1.isPresent());
 
         ThingCreate create2 = ThingCreate.builder()
             .urn(urn)
             .type("type2")
             .build();
-        Optional<ThingResponse> response2 = persistenceService
+        Optional<ThingResponse> createResponse2 = persistenceService
             .create(tenantUrn, create2);
-        assertTrue(response2.isPresent());
+        assertTrue(createResponse2.isPresent());
+        assertEquals("type2", createResponse2.get().getType());
+        assertEquals(urn, createResponse2.get().getUrn());
+
+        Optional<ThingResponse> persistResponse2 = persistenceService.findByTypeAndUrn(tenantUrn, "type2", urn);
+        assertTrue(persistResponse2.isPresent());
     }
 
     // endregion


### PR DESCRIPTION
### What changes were proposed in this pull request?

The primary key `id` is replaced by a new composite primary key consisting of `id`, `tenantId` and `type`.

This allows for having multiple Things with the same URN, but different types, that not even have to be unique across tenants.

Previously it seemed to be possible to create multiple things with the same URN, but different types. However, the second Thing didn't get persisted although everything seemed to be successful.
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests and Postman.

The existing unit test `ThingPersistenceServiceTest.thatDuplicateIdDifferentTypeSucceeds()` is improved: It now checks if the types really match, and if the created Things actually can be retrieved from the datastore.
#### Depends On

Nothing.
