### PR TITLE
Fix page information in converter (for empty pages)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,15 @@
+= SMART COSMOS DAO Things for JPA Release Notes
+
+== UNRELEASED
+
+=== New Features
+
+No new features are added in this release.
+
+=== Bugfixes & Improvements
+
+* OBJECTS-979 Empty page response returns incorrect number of pages
+
+== Release 3.0.0 (August 12, 2016)
+
+Initial release.

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= SMART COSMOS DAO Objects for JPA
+= SMART COSMOS DAO Things for JPA
 SMARTRAC Technology Fletcher Inc <api@smartrac-group.com>
 ifdef::env-github[:USER: SMARTRACTECHNOLOGY]
 ifdef::env-github[:REPO: smartcosmos-dao-things-default]

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
             <dependency>
                 <groupId>net.smartcosmos</groupId>
                 <artifactId>smartcosmos-dao-things</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverter.java
+++ b/src/main/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverter.java
@@ -31,7 +31,7 @@ public class SpringDataPageToThingResponsePageConverter
             .number((page.getTotalElements() > 0 ? page.getNumber() + 1 : 0))
             .totalElements(page.getTotalElements())
             .size(page.getNumberOfElements())
-            .totalPages(page.getTotalPages())
+            .totalPages((page.getNumberOfElements() > 0 ? page.getTotalPages() : 0))
             .build();
 
         List<ThingResponse> data = page.getContent()

--- a/src/test/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverterTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/converter/SpringDataPageToThingResponsePageConverterTest.java
@@ -1,0 +1,87 @@
+package net.smartcosmos.dao.things.converter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.*;
+import org.junit.runner.*;
+import org.mockito.*;
+import org.mockito.runners.*;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.data.domain.PageImpl;
+
+import net.smartcosmos.dao.things.domain.ThingEntity;
+import net.smartcosmos.dao.things.util.ThingPersistenceUtil;
+import net.smartcosmos.dao.things.util.UuidUtil;
+import net.smartcosmos.dto.things.Page;
+import net.smartcosmos.dto.things.PageInformation;
+import net.smartcosmos.dto.things.ThingResponse;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpringDataPageToThingResponsePageConverterTest {
+
+    @Mock
+    ConversionService conversionService;
+
+    @InjectMocks
+    SpringDataPageToThingResponsePageConverter converter;
+
+    @Test
+    public void testConversionService() throws Exception {
+
+        ThingEntity entity = ThingEntity.builder()
+            .id(UuidUtil.getNewUuid())
+            .tenantId(UuidUtil.getNewUuid())
+            .active(true)
+            .build();
+        List<ThingEntity> content = new ArrayList<>();
+        content.add(entity);
+
+        when(conversionService.convert(eq(entity), eq(ThingResponse.class))).thenReturn(mock(ThingResponse.class));
+
+        org.springframework.data.domain.Page<ThingEntity> entityPage = new PageImpl<>(content);
+        Page<ThingResponse> convertedPage = converter.convert(entityPage);
+
+        List<ThingResponse> data = convertedPage.getData();
+        assertNotNull(data);
+        assertFalse(data.isEmpty());
+        ThingResponse response = data.get(0);
+        assertEquals(1, data.size());
+
+        PageInformation page = convertedPage.getPage();
+        assertNotNull(page);
+        assertEquals(1, page.getNumber());
+        assertEquals(1, page.getSize());
+        assertEquals(1, page.getTotalPages());
+        assertEquals(1, page.getTotalElements());
+    }
+
+    @Test
+    public void thatEmptyPageConversionSucceeds() {
+
+        List<ThingEntity> content = new ArrayList<>();
+        org.springframework.data.domain.Page<ThingEntity> emptyEntityPage = new PageImpl<>(content);
+
+        Page<ThingResponse> convertedPage = converter.convert(emptyEntityPage);
+
+        Collection<ThingResponse> data = convertedPage.getData();
+        assertNotNull(data);
+        assertTrue(data.isEmpty());
+
+        PageInformation page = convertedPage.getPage();
+        assertNotNull(page);
+        assertEquals(0, page.getSize());
+        assertEquals(0, page.getNumber());
+        assertEquals(0, page.getTotalPages());
+        assertEquals(0, page.getTotalElements());
+
+        Page<ThingResponse> emptyPage = ThingPersistenceUtil.emptyPage();
+        assertEquals(emptyPage, convertedPage);
+    }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the empty page response, which previously contained incorrect values for `totalPages` and `number`.

Also makes sure, that the page information aren't `null` when using the builder.
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests.
#### Depends On

Builder fix in https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-things/pull/46
