### PR TITLE
Look up Thing by URN and Type without tenant URN

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,7 +4,7 @@
 
 === New Features
 
-No new features are added in this release.
+* Find by Type and URN also supports cross-tenant lookups
 
 === Bugfixes & Improvements
 

--- a/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/things/impl/ThingPersistenceService.java
@@ -178,10 +178,16 @@ public class ThingPersistenceService implements ThingDao {
     public Optional<ThingResponse> findByTypeAndUrn(String tenantUrn, String type, String urn) {
 
         try {
-            UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
             UUID id = UuidUtil.getUuidFromUrn(urn);
+            
+            Optional<ThingEntity> entity;
+            if (StringUtils.isNotBlank(tenantUrn)) {
+                UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
+                entity = repository.findByIdAndTenantIdAndTypeIgnoreCase(id, tenantId, type);
+            } else {
+                entity = repository.findByIdAndTypeIgnoreCase(id, type);
+            }
 
-            Optional<ThingEntity> entity = repository.findByIdAndTenantIdAndTypeIgnoreCase(id, tenantId, type);
             if (entity.isPresent()) {
                 return Optional.ofNullable(conversionService.convert(entity.get(), ThingResponse.class));
             }

--- a/src/main/java/net/smartcosmos/dao/things/repository/ThingRepository.java
+++ b/src/main/java/net/smartcosmos/dao/things/repository/ThingRepository.java
@@ -25,6 +25,8 @@ public interface ThingRepository
 
     Optional<ThingEntity> findByIdAndTenantIdAndTypeIgnoreCase(UUID id, UUID tenantId, String type);
 
+    Optional<ThingEntity> findByIdAndTypeIgnoreCase(UUID id, String type);
+
     Optional<ThingEntity> findByIdAndTenantId(UUID id, UUID tenantId);
 
     Page<ThingEntity> findByTenantIdAndTypeIgnoreCase(UUID tenantId, String type, Pageable pageable);


### PR DESCRIPTION
### What changes were proposed in this pull request?

It's possible to look up Things by Type and URN without providing a Tenant URN now.
### How is this patch documented?

Code.
### How was this patch tested?

Existing unit tests.
#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-ext-things-rdao/pull/56
