### PR TITLE
Add missing unique constraint

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@
 === Bugfixes & Improvements
 
 * OBJECTS-979 Empty page response returns incorrect number of pages
+* OBJECTS-1010 Duplicate Thing Urn through Edge Service responds with 500
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/dao/things/domain/ThingEntity.java
+++ b/src/main/java/net/smartcosmos/dao/things/domain/ThingEntity.java
@@ -13,6 +13,7 @@ import javax.persistence.IdClass;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -32,7 +33,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @EntityListeners({ AuditingEntityListener.class })
-@Table(name = "thing")
+@Table(name = "thing", uniqueConstraints = @UniqueConstraint(columnNames = { "id", "type", "tenantId" }))
 public class ThingEntity implements Serializable {
 
     private static final int UUID_LENGTH = 16;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds an explicit unique constraint to the `thing` table:

```
uniqueConstraints = @UniqueConstraint(columnNames = { "id", "type", "tenantId" })
```

For some reason, the `@IdClass` annotation did not result in such an index in the database. Adding at explicitly, solves the problem described in [OBJECTS-1010](https://smartractechnology.atlassian.net/browse/OBJECTS-1010).
### How is this patch documented?

Code.
### How was this patch tested?
- manually in Postman.
#### Depends On

Nothing.
