### PR TITLE
Bugfix/objects 1007

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@
 
 * OBJECTS-979 Empty page response returns incorrect number of pages
 * OBJECTS-1010 Duplicate Thing Urn through Edge Service responds with 500
+* OBJECTS-1007 Invalid URN scheme results in 500 response, and URN scheme is not checked correctly
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,6 @@ ifdef::env-github[:USER: SMARTRACTECHNOLOGY]
 ifdef::env-github[:REPO: smartcosmos-dao-things-default]
 ifdef::env-github[:BRANCH: master]
 
-image::https://travis-ci.org/{USER}/{REPO}.svg?branch={BRANCH}[Build Status, link=https://travis-ci.org/{USER}/{REPO}]
+image::https://jenkins.smartcosmos.net/buildStatus/icon?job={USER}/{REPO}/{BRANCH}[Build Status, link=https://jenkins.smartcosmos.net/job/{USER}/job/{REPO}/job/{BRANCH}/]
 
 Implementation of the Objects DAO for JPA (relational databases).  This is an example implementation that defines a historical database structure closely resembling previous versions of Objects to facilitate a migration pattern for those moving into the next major release.

--- a/src/main/java/net/smartcosmos/dao/things/util/UuidUtil.java
+++ b/src/main/java/net/smartcosmos/dao/things/util/UuidUtil.java
@@ -19,7 +19,7 @@ public class UuidUtil {
 
     public static UUID getUuidFromUrn(String urn) throws IllegalArgumentException {
 
-        String urnScheme = "urn:.*:uuid:([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})";
+        String urnScheme = "^urn:.*:uuid:([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})$";
 
         Pattern p = Pattern.compile(urnScheme, Pattern.CASE_INSENSITIVE);
         Matcher m = p.matcher(urn);

--- a/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/impl/ThingPersistenceServiceTest.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.junit.*;
-import org.junit.runner.*;
+import org.junit.runner.RunWith;
 import org.mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
@@ -266,16 +266,14 @@ public class ThingPersistenceServiceTest {
                          .getActive());
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void thatUpdateNonexistentByTypeAndUrnFails() {
 
         ThingUpdate update = ThingUpdate.builder()
             .active(false)
             .build();
 
-        Optional<ThingResponse> responseUpdate = persistenceService.update(tenantUrn, "NO SUCH TYPE", "URN:DOES-NOT-EXIST", update);
-
-        assertFalse(responseUpdate.isPresent());
+        persistenceService.update(tenantUrn, "NO SUCH TYPE", "URN:DOES-NOT-EXIST", update);
     }
 
     // endregion

--- a/src/test/java/net/smartcosmos/dao/things/util/UuidUtilTest.java
+++ b/src/test/java/net/smartcosmos/dao/things/util/UuidUtilTest.java
@@ -26,6 +26,20 @@ public class UuidUtilTest {
         UuidUtil.getUuidFromUrn(urn);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void getUuidFromInvaldiUrnPrefix() throws Exception {
+
+        final String urn = "INVALID-urn:thing:uuid:8e24eabd-1be9-46ac-8c7d-1e753746b413";
+        UuidUtil.getUuidFromUrn(urn);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getUuidFromInvaldiUrnSuffix() throws Exception {
+
+        final String urn = "urn:thing:uuid:8e24eabd-1be9-46ac-8c7d-1e753746b413-INVALID";
+        UuidUtil.getUuidFromUrn(urn);
+    }
+
     @Test
     public void getThingUrnFromUuid() throws Exception {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
- removes `try {} catch ()` blocks for `IllegalArgumentException` because they never really worked, and the exceptions are now handled in Framework's `RequestExceptionHandler` controller advice
- fixes the URN scheme, so that `bogus_<valid URN>` or `<valid URN>_bogus` is not valid anymore
- adds Jenkins build status 😎 
### How is this patch documented?

Code
### How was this patch tested?

existing tests and manually in Postman
#### Depends On

`RequestExceptionHandler` controller advice in https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/pull/198
